### PR TITLE
feat: display the IT request category list

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,16 +1,18 @@
 import { useState } from "react";
-import { checkSystem } from "./api.js";
+import { Category, checkSystem } from "./api.js";
 
 // UI states you must handle for Issue 4: idle, loading, success, error.
 type UiState = "idle" | "loading" | "success" | "error";
 
 export default function App() {
   const [state, setState] = useState<UiState>("idle");
+  const [categories, setCategories] = useState<Category[]>([]);
 
   async function handleCheck() {
     setState("loading");
     try {
-      await checkSystem();
+      const result = await checkSystem();
+      setCategories(result.categories);
       setState("success");
     } catch {
       setState("error");
@@ -27,7 +29,15 @@ export default function App() {
         {state === "loading" ? "Loading…" : "Check System"}
       </button>
 
-      {state === "success" && <p className="text-success mt-3">Online</p>}
+      {state === "success" && (
+        <div className="mt-3">
+          <p className="text-success">System Status: Online</p>
+          <h2 className="h5">Supported Request Categories:</h2>
+          <ul>
+            {categories.map((category) => <li key={category.id}>{category.name}</li>)}
+          </ul>
+        </div>
+      )}
       {state === "error" && (
         <p className="text-danger mt-3">Offline — Unable to reach the API. Please try again.</p>
       )}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -26,20 +26,38 @@ export default function App() {
       </h1>
 
       <button className="btn btn-success" onClick={handleCheck} disabled={state === "loading"}>
+        {state === "loading" && <span className="spinner-border spinner-border-sm me-2" aria-hidden="true" />}
         {state === "loading" ? "Loading…" : "Check System"}
       </button>
 
       {state === "success" && (
-        <div className="mt-3">
-          <p className="text-success">System Status: Online</p>
-          <h2 className="h5">Supported Request Categories:</h2>
-          <ul>
-            {categories.map((category) => <li key={category.id}>{category.name}</li>)}
-          </ul>
+        <div className="mt-4">
+          <div className="alert alert-success d-flex align-items-center gap-3" role="status">
+            <span className="fs-4" aria-hidden="true">✓</span>
+            <div>
+              <div className="fw-semibold">System Status</div>
+              <div>Online</div>
+            </div>
+          </div>
+
+          <div className="card shadow-sm">
+            <div className="card-header fw-semibold">Supported Request Categories</div>
+            <ul className="list-group list-group-flush">
+              {categories.map((category, index) => (
+                <li className="list-group-item d-flex align-items-center gap-3" key={category.id}>
+                  <span className="badge text-bg-success rounded-pill">{index + 1}</span>
+                  <span>{category.name}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
       )}
       {state === "error" && (
-        <p className="text-danger mt-3">Offline — Unable to reach the API. Please try again.</p>
+        <div className="alert alert-danger mt-4" role="alert">
+          <div className="fw-semibold">System Status: Offline</div>
+          <div>Unable to reach the API. Please try again.</div>
+        </div>
       )}
     </div>
   );

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -7,11 +7,16 @@ export interface Category {
 
 export interface SystemStatus {
   online: boolean;
+  categories: Category[];
 }
 
-// Issue 2 — call the health endpoint. Issue 4 will add categories here.
 export async function checkSystem(): Promise<SystemStatus> {
-  const response = await fetch(`${API_URL}/api/health`);
-  if (!response.ok) throw new Error("Backend health check failed");
-  return { online: true };
+  const [healthResponse, categoriesResponse] = await Promise.all([
+    fetch(`${API_URL}/api/health`),
+    fetch(`${API_URL}/api/categories`),
+  ]);
+  if (!healthResponse.ok || !categoriesResponse.ok) throw new Error("System check failed");
+
+  const health = await healthResponse.json();
+  return { online: health.status === "ok", categories: await categoriesResponse.json() };
 }

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -14,13 +14,27 @@ describe("App", () => {
   });
 
   it("shows Online when the health check succeeds", async () => {
-    vi.spyOn(api, "checkSystem").mockResolvedValue({ online: true });
+    vi.spyOn(api, "checkSystem").mockResolvedValue({
+      online: true,
+      categories: [{ id: 1, name: "Account and Access" }],
+    });
     const user = userEvent.setup();
     render(<App />);
 
     await user.click(screen.getByRole("button", { name: "Check System" }));
 
-    expect(await screen.findByText("Online")).toBeInTheDocument();
+    expect(await screen.findByText("System Status: Online")).toBeInTheDocument();
+    expect(screen.getByText("Account and Access")).toBeInTheDocument();
+  });
+
+  it("shows a loading state while the system check is pending", async () => {
+    vi.spyOn(api, "checkSystem").mockReturnValue(new Promise(() => {}));
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.click(screen.getByRole("button", { name: "Check System" }));
+
+    expect(screen.getByRole("button", { name: "Loading…" })).toBeDisabled();
   });
 
   it("shows a useful Offline error when the API is unavailable", async () => {

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -23,7 +23,8 @@ describe("App", () => {
 
     await user.click(screen.getByRole("button", { name: "Check System" }));
 
-    expect(await screen.findByText("System Status: Online")).toBeInTheDocument();
+    expect(await screen.findByText("System Status")).toBeInTheDocument();
+    expect(screen.getByText("Online")).toBeInTheDocument();
     expect(screen.getByText("Account and Access")).toBeInTheDocument();
   });
 
@@ -44,6 +45,8 @@ describe("App", () => {
 
     await user.click(screen.getByRole("button", { name: "Check System" }));
 
-    expect(await screen.findByText(/Offline — Unable to reach the API/i)).toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /System Status.*Offline.*Unable to reach the API/,
+    );
   });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,5 +1,6 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
+import { getPrisma } from "./prisma.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -17,13 +18,16 @@ app.get("/api/health", (_req: Request, res: Response) => {
   res.json({ status: "ok", service: "TokTickIT API" });
 });
 
-// ---------------------------------------------------------------------------
-// Issue 4 — Category list
-// Add:  GET /api/categories
-//   -> read categories from PostgreSQL via getPrisma().category.findMany(...)
-//   -> return each { id, name } in a predictable (id) order
-//   -> on failure, respond 500 with a safe message (no internal details)
-// TODO(Issue 4): implement the route here.
-// ---------------------------------------------------------------------------
+app.get("/api/categories", async (_req: Request, res: Response) => {
+  try {
+    const categories = await getPrisma().category.findMany({
+      select: { id: true, name: true },
+      orderBy: { id: "asc" },
+    });
+    res.json(categories);
+  } catch {
+    res.status(500).json({ error: "Unable to load request categories" });
+  }
+});
 
 export default app;

--- a/server/tests/lab-01/categories.test.ts
+++ b/server/tests/lab-01/categories.test.ts
@@ -1,15 +1,18 @@
 import { describe, it, expect } from "vitest";
 import request from "supertest";
 import { app } from "../../src/app.js";
-void request; void app;
 
-// Issue 4 — write this test yourself, using health.test.ts as the pattern.
 // Requires the DB to be migrated and seeded first.
-// It should assert: GET /api/categories returns 200 and the four seeded
-// category names in id order.
-describe.todo("GET /api/categories", () => {
-  it.todo("returns the four seeded categories in id order", async () => {
-    // TODO(Issue 4): implement this assertion.
-    expect(true).toBe(true);
+describe("GET /api/categories", () => {
+  it("returns the four seeded categories in id order", async () => {
+    const res = await request(app).get("/api/categories");
+
+    expect(res.status).toBe(200);
+    expect(res.body.map((category: { name: string }) => category.name)).toEqual([
+      "Account and Access",
+      "Hardware",
+      "Software",
+      "Network",
+    ]);
   });
 });


### PR DESCRIPTION
### Display the IT request category list

**Issue**: #4 

**Description**: This pull request implements the "Request Categories" feature, connecting the frontend and backend to display a list of supported request categories retrieved from the database.

**Acceptance criteria**:

- GET /api/categories retrieves categories from PostgreSQL through Prisma.
- The API returns each category ID and name in a predictable order.
- A Supertest test verifies the response.
- React displays the categories returned by the API, not hard-coded values.
- Loading and error states are shown.
- A Vitest test verifies the category-list UI behavior.

**Test**:

1. Backend test

```sh
$ curl http://localhost:3000/api/categories | jq
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                 Dload  Upload  Total   Spent   Left   Speed
100    118 100    118   0      0  27895      0                              0
[
  {
    "id": 1,
    "name": "Account and Access"
  },
  {
    "id": 2,
    "name": "Hardware"
  },
  {
    "id": 3,
    "name": "Software"
  },
  {
    "id": 4,
    "name": "Network"
  }
]

$ npx vitest run tests/lab-01/categories.test.ts

 RUN  v2.1.9 /home/jb/Workspace/toktickit/server

 ✓ tests/lab-01/categories.test.ts (1)
   ✓ GET /api/categories (1)
     ✓ returns the four seeded categories in id order

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  21:45:56
   Duration  354ms (transform 34ms, setup 0ms, collect 99ms, tests 41ms, environment 0ms, prepare 36ms)
```
---
2. Frontend test

```sh
$ npx vitest run tests/lab-01/App.test.tsx

> toktickit-client@1.0.0 test
> vitest run


 RUN  v2.1.9 /home/jb/Workspace/toktickit/client

 ✓ tests/lab-01/App.test.tsx (4)
   ✓ App (4)
     ✓ renders the TokTickIT heading
     ✓ shows Online when the health check succeeds
     ✓ shows a loading state while the system check is pending
     ✓ shows a useful Offline error when the API is unavailable

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  22:01:14
   Duration  748ms (transform 98ms, setup 41ms, collect 141ms, tests 106ms, environment 232ms, prepare 64ms)
```

<img width="230" height="158" alt="image" src="https://github.com/user-attachments/assets/22a03144-589e-4204-b835-778b0435a31b" width="49%" />
<img width="331" height="120" alt="image" src="https://github.com/user-attachments/assets/b7862b22-ad65-41af-b0c9-9a9fb075a04b" width="49%" />