### PR TITLE
feat: add Lab 2 data foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ node_modules/
 dist/
 build/
 coverage/
+server/uploads/
 
 # Vite and TypeScript caches
 .vite/

--- a/server/prisma/migrations/20260825000000_lab2_ticketing/migration.sql
+++ b/server/prisma/migrations/20260825000000_lab2_ticketing/migration.sql
@@ -1,0 +1,77 @@
+-- CreateEnum
+CREATE TYPE "RequestedPriority" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'URGENT');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('NEW');
+
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN "isActive" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateTable
+CREATE TABLE "Requester" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Requester_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RelatedSystem" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RelatedSystem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" SERIAL NOT NULL,
+    "ticketNumber" VARCHAR(32) NOT NULL,
+    "requesterId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+    "relatedSystemId" INTEGER NOT NULL,
+    "requestedPriority" "RequestedPriority" NOT NULL DEFAULT 'MEDIUM',
+    "status" "TicketStatus" NOT NULL DEFAULT 'NEW',
+    "summary" VARCHAR(200) NOT NULL,
+    "description" VARCHAR(4000) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" SERIAL NOT NULL,
+    "ticketId" INTEGER NOT NULL,
+    "originalName" VARCHAR(255) NOT NULL,
+    "storageKey" VARCHAR(64) NOT NULL,
+    "mimeType" VARCHAR(100) NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "removedAt" TIMESTAMP(3),
+    "removalReason" VARCHAR(500),
+
+    CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Requester_email_key" ON "Requester"("email");
+CREATE INDEX "Requester_isActive_name_idx" ON "Requester"("isActive", "name");
+CREATE UNIQUE INDEX "RelatedSystem_name_key" ON "RelatedSystem"("name");
+CREATE UNIQUE INDEX "Ticket_ticketNumber_key" ON "Ticket"("ticketNumber");
+CREATE INDEX "Ticket_requesterId_updatedAt_idx" ON "Ticket"("requesterId", "updatedAt");
+CREATE UNIQUE INDEX "Attachment_storageKey_key" ON "Attachment"("storageKey");
+CREATE INDEX "Attachment_ticketId_removedAt_idx" ON "Attachment"("ticketId", "removedAt");
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "Requester"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_relatedSystemId_fkey" FOREIGN KEY ("relatedSystemId") REFERENCES "RelatedSystem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -13,5 +13,73 @@ datasource db {
 model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  isActive  Boolean  @default(true)
   createdAt DateTime @default(now())
+  tickets   Ticket[]
+}
+
+enum RequestedPriority {
+  LOW
+  MEDIUM
+  HIGH
+  URGENT
+}
+
+enum TicketStatus {
+  NEW
+}
+
+model Requester {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  tickets   Ticket[]
+
+  @@index([isActive, name])
+}
+
+model RelatedSystem {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  tickets   Ticket[]
+}
+
+model Ticket {
+  id                Int               @id @default(autoincrement())
+  ticketNumber      String            @unique @db.VarChar(32)
+  requesterId       Int
+  categoryId        Int
+  relatedSystemId   Int
+  requestedPriority RequestedPriority @default(MEDIUM)
+  status            TicketStatus      @default(NEW)
+  summary           String            @db.VarChar(200)
+  description       String            @db.VarChar(4000)
+  createdAt         DateTime          @default(now())
+  updatedAt         DateTime          @updatedAt
+  requester         Requester         @relation(fields: [requesterId], references: [id])
+  category          Category          @relation(fields: [categoryId], references: [id])
+  relatedSystem     RelatedSystem     @relation(fields: [relatedSystemId], references: [id])
+  attachments       Attachment[]
+
+  @@index([requesterId, updatedAt])
+}
+
+model Attachment {
+  id            Int       @id @default(autoincrement())
+  ticketId      Int
+  originalName  String    @db.VarChar(255)
+  storageKey    String    @unique @db.VarChar(64)
+  mimeType      String    @db.VarChar(100)
+  sizeBytes     Int
+  createdAt     DateTime  @default(now())
+  removedAt     DateTime?
+  removalReason String?   @db.VarChar(500)
+  ticket        Ticket    @relation(fields: [ticketId], references: [id])
+
+  @@index([ticketId, removedAt])
 }

--- a/server/prisma/seed-data.ts
+++ b/server/prisma/seed-data.ts
@@ -1,0 +1,23 @@
+import type { PrismaClient } from "@prisma/client";
+
+export const categories = ["Account and Access", "Hardware", "Software", "Network"] as const;
+export const relatedSystems = ["Email", "Campus Wi-Fi", "VPN", "LEB2 App", "Grade Submission App", "Printer"] as const;
+export const requesters = [
+  { name: "Nicha Somchai", email: "nicha.somchai@toktickit.test", isActive: true },
+  { name: "Anan Kittisak", email: "anan.kittisak@toktickit.test", isActive: true },
+  { name: "Mali Charoen", email: "mali.charoen@toktickit.test", isActive: true },
+  { name: "Preecha Wattanakul", email: "preecha.wattanakul@toktickit.test", isActive: true },
+  { name: "Suda Inactive", email: "suda.inactive@toktickit.test", isActive: false },
+] as const;
+
+export async function seedDatabase(prisma: Pick<PrismaClient, "category" | "relatedSystem" | "requester">) {
+  for (const name of categories) {
+    await prisma.category.upsert({ where: { name }, update: { isActive: true }, create: { name } });
+  }
+  for (const name of relatedSystems) {
+    await prisma.relatedSystem.upsert({ where: { name }, update: { isActive: true }, create: { name } });
+  }
+  for (const requester of requesters) {
+    await prisma.requester.upsert({ where: { email: requester.email }, update: { name: requester.name, isActive: requester.isActive }, create: requester });
+  }
+}

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,10 +1,8 @@
 import { getPrisma } from "../src/prisma.js";
+import { seedDatabase } from "./seed-data.js";
 
 async function main() {
-  const prisma = getPrisma();
-  for (const name of ["Account and Access", "Hardware", "Software", "Network"]) {
-    await prisma.category.upsert({ where: { name }, update: {}, create: { name } });
-  }
+  await seedDatabase(getPrisma());
 }
 
 main()

--- a/server/tests/lab-02/database-seed.test.ts
+++ b/server/tests/lab-02/database-seed.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { categories, relatedSystems, requesters, seedDatabase } from "../../prisma/seed-data.js";
+
+describe("Lab 2 seed data", () => {
+  it("defines the required reference data and uses unique-key upserts", async () => {
+    expect(categories).toHaveLength(4);
+    expect(relatedSystems).toHaveLength(6);
+    expect(requesters.filter((requester) => requester.isActive)).toHaveLength(4);
+    expect(requesters.filter((requester) => !requester.isActive)).toHaveLength(1);
+
+    const prisma = {
+      category: { upsert: vi.fn().mockResolvedValue({}) },
+      relatedSystem: { upsert: vi.fn().mockResolvedValue({}) },
+      requester: { upsert: vi.fn().mockResolvedValue({}) },
+    };
+    await seedDatabase(prisma as never);
+    await seedDatabase(prisma as never);
+
+    expect(prisma.category.upsert).toHaveBeenCalledTimes(categories.length * 2);
+    expect(prisma.relatedSystem.upsert).toHaveBeenCalledTimes(relatedSystems.length * 2);
+    expect(prisma.requester.upsert).toHaveBeenCalledWith(expect.objectContaining({ where: { email: requesters[0].email } }));
+  });
+});


### PR DESCRIPTION
## Summary
- add the Lab 2 Prisma models, enums, and additive migration
- add idempotent seed data for categories, related systems, and requesters
- add a seed-data test and ignore local upload storage

## Verification
- npx prisma migrate status
- npx prisma db seed
- npm test
- npm run build

Relates to #12