### PR TITLE
feat: add requester context and reference data

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,64 +1,92 @@
-import { useState } from "react";
-import { Category, checkSystem } from "./api.js";
+import { useEffect, useState } from "react";
+import { type ReferenceData, loadReferenceData } from "./api.js";
 
-// UI states you must handle for Issue 4: idle, loading, success, error.
-type UiState = "idle" | "loading" | "success" | "error";
+type LoadState = "loading" | "ready" | "error";
+const requesterStorageKey = "toktickit.requesterId";
+
+function savedRequesterId() {
+  const id = Number(sessionStorage.getItem(requesterStorageKey));
+  return Number.isInteger(id) && id > 0 ? id : null;
+}
 
 export default function App() {
-  const [state, setState] = useState<UiState>("idle");
-  const [categories, setCategories] = useState<Category[]>([]);
+  const [state, setState] = useState<LoadState>("loading");
+  const [referenceData, setReferenceData] = useState<ReferenceData | null>(null);
+  const [requesterId, setRequesterId] = useState<number | null>(savedRequesterId);
+  const [pendingRequesterId, setPendingRequesterId] = useState<number | null>(null);
 
-  async function handleCheck() {
+  async function load() {
     setState("loading");
     try {
-      const result = await checkSystem();
-      setCategories(result.categories);
-      setState("success");
+      const data = await loadReferenceData();
+      setReferenceData(data);
+      setRequesterId((id) => data.requesters.some((requester) => requester.id === id) ? id : null);
+      setState("ready");
     } catch {
       setState("error");
     }
   }
 
+  useEffect(() => { void load(); }, []);
+
+  const requester = referenceData?.requesters.find((item) => item.id === requesterId);
+
+  function continueWithRequester() {
+    if (!pendingRequesterId) return;
+    setRequesterId(pendingRequesterId);
+    sessionStorage.setItem(requesterStorageKey, String(pendingRequesterId));
+  }
+
+  function changeRequester() {
+    sessionStorage.removeItem(requesterStorageKey);
+    setRequesterId(null);
+    setPendingRequesterId(null);
+  }
+
   return (
-    <div className="container py-5" style={{ maxWidth: 640 }}>
-      <h1 className="h3 mb-4">
-        TokTickIT <span className="text-success">IT Service Desk</span>
-      </h1>
+    <main className="container py-5" style={{ maxWidth: 640 }}>
+      <header className="mb-4">
+        <h1 className="h3 mb-1" style={{ color: "#006B3C" }}>TokTickIT</h1>
+        <p className="text-secondary mb-0">IT Service Desk</p>
+      </header>
 
-      <button className="btn btn-success" onClick={handleCheck} disabled={state === "loading"}>
-        {state === "loading" && <span className="spinner-border spinner-border-sm me-2" aria-hidden="true" />}
-        {state === "loading" ? "Loading…" : "Check System"}
-      </button>
+      {state === "loading" && <p role="status">Loading Development Requesters…</p>}
 
-      {state === "success" && (
-        <div className="mt-4">
-          <div className="alert alert-success d-flex align-items-center gap-3" role="status">
-            <span className="fs-4" aria-hidden="true">✓</span>
-            <div>
-              <div className="fw-semibold">System Status</div>
-              <div>Online</div>
-            </div>
-          </div>
-
-          <div className="card shadow-sm">
-            <div className="card-header fw-semibold">Supported Request Categories</div>
-            <ul className="list-group list-group-flush">
-              {categories.map((category, index) => (
-                <li className="list-group-item d-flex align-items-center gap-3" key={category.id}>
-                  <span className="badge text-bg-success rounded-pill">{index + 1}</span>
-                  <span>{category.name}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      )}
       {state === "error" && (
-        <div className="alert alert-danger mt-4" role="alert">
-          <div className="fw-semibold">System Status: Offline</div>
-          <div>Unable to reach the API. Please try again.</div>
+        <div className="alert alert-danger" role="alert">
+          <p className="mb-3">Unable to load requester and reference data.</p>
+          <button className="btn btn-danger" onClick={load}>Retry</button>
         </div>
       )}
-    </div>
+
+      {state === "ready" && !requester && referenceData?.requesters.length === 0 && (
+        <div className="alert alert-warning" role="status">No active Development Requesters are available.</div>
+      )}
+
+      {state === "ready" && !requester && referenceData && referenceData.requesters.length > 0 && (
+        <section className="card shadow-sm">
+          <div className="card-body">
+            <h2 className="h4">Select Development Requester</h2>
+            <p>This selector is for Lab 2 testing only. It is not a login screen.</p>
+            <label className="form-label fw-semibold" htmlFor="requester">Development Requester</label>
+            <select className="form-select mb-3" id="requester" value={pendingRequesterId ?? ""} onChange={(event) => setPendingRequesterId(Number(event.target.value) || null)}>
+              <option value="">Choose a requester</option>
+              {referenceData.requesters.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}
+            </select>
+            <button className="btn text-white" style={{ backgroundColor: "#006B3C" }} disabled={!pendingRequesterId} onClick={continueWithRequester}>Continue</button>
+          </div>
+        </section>
+      )}
+
+      {state === "ready" && requester && referenceData && (
+        <section className="card shadow-sm" style={{ borderColor: "#EAF6EF" }}>
+          <div className="card-body">
+            <p className="fw-semibold mb-2">Current requester: {requester.name}</p>
+            <p>Reference data ready: {referenceData.categories.length} {referenceData.categories.length === 1 ? "category" : "categories"} and {referenceData.relatedSystems.length} {referenceData.relatedSystems.length === 1 ? "related system" : "related systems"}.</p>
+            <button className="btn btn-outline-success" onClick={changeRequester}>Change Requester</button>
+          </div>
+        </section>
+      )}
+    </main>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,22 +1,32 @@
 const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
 
-export interface Category {
+export interface ReferenceItem {
   id: number;
   name: string;
 }
 
-export interface SystemStatus {
-  online: boolean;
-  categories: Category[];
+export interface Requester extends ReferenceItem {
+  email: string;
 }
 
-export async function checkSystem(): Promise<SystemStatus> {
-  const [healthResponse, categoriesResponse] = await Promise.all([
-    fetch(`${API_URL}/api/health`),
-    fetch(`${API_URL}/api/categories`),
-  ]);
-  if (!healthResponse.ok || !categoriesResponse.ok) throw new Error("System check failed");
+export interface ReferenceData {
+  requesters: Requester[];
+  categories: ReferenceItem[];
+  relatedSystems: ReferenceItem[];
+}
 
-  const health = await healthResponse.json();
-  return { online: health.status === "ok", categories: await categoriesResponse.json() };
+async function loadJson<T>(path: string): Promise<T> {
+  const response = await fetch(`${API_URL}${path}`);
+  if (!response.ok) throw new Error("Reference data request failed");
+  return response.json() as Promise<T>;
+}
+
+export async function loadReferenceData(): Promise<ReferenceData> {
+  const [requesters, categories, relatedSystems] = await Promise.all([
+    loadJson<Requester[]>("/api/requesters"),
+    loadJson<ReferenceItem[]>("/api/categories"),
+    loadJson<ReferenceItem[]>("/api/related-systems"),
+  ]);
+
+  return { requesters, categories, relatedSystems };
 }

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -1,52 +1,16 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import App from "../../src/App.js";
 import * as api from "../../src/api.js";
 
 afterEach(() => vi.restoreAllMocks());
 
 describe("App", () => {
-  // WORKED EXAMPLE — provided for you.
-  it("renders the TokTickIT heading", () => {
+  it("renders the TokTickIT heading", async () => {
+    vi.spyOn(api, "loadReferenceData").mockResolvedValue({ requesters: [], categories: [], relatedSystems: [] });
     render(<App />);
+
     expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
-  });
-
-  it("shows Online when the health check succeeds", async () => {
-    vi.spyOn(api, "checkSystem").mockResolvedValue({
-      online: true,
-      categories: [{ id: 1, name: "Account and Access" }],
-    });
-    const user = userEvent.setup();
-    render(<App />);
-
-    await user.click(screen.getByRole("button", { name: "Check System" }));
-
-    expect(await screen.findByText("System Status")).toBeInTheDocument();
-    expect(screen.getByText("Online")).toBeInTheDocument();
-    expect(screen.getByText("Account and Access")).toBeInTheDocument();
-  });
-
-  it("shows a loading state while the system check is pending", async () => {
-    vi.spyOn(api, "checkSystem").mockReturnValue(new Promise(() => {}));
-    const user = userEvent.setup();
-    render(<App />);
-
-    await user.click(screen.getByRole("button", { name: "Check System" }));
-
-    expect(screen.getByRole("button", { name: "Loading…" })).toBeDisabled();
-  });
-
-  it("shows a useful Offline error when the API is unavailable", async () => {
-    vi.spyOn(api, "checkSystem").mockRejectedValue(new Error("Backend unavailable"));
-    const user = userEvent.setup();
-    render(<App />);
-
-    await user.click(screen.getByRole("button", { name: "Check System" }));
-
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      /System Status.*Offline.*Unable to reach the API/,
-    );
+    expect(await screen.findByText("No active Development Requesters are available.")).toBeInTheDocument();
   });
 });

--- a/client/tests/lab-02/RequesterSelection.test.tsx
+++ b/client/tests/lab-02/RequesterSelection.test.tsx
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import App from "../../src/App.js";
+import * as api from "../../src/api.js";
+
+const referenceData = {
+  requesters: [{ id: 1, name: "Nicha Somchai", email: "nicha@example.test" }],
+  categories: [{ id: 1, name: "Hardware" }],
+  relatedSystems: [{ id: 1, name: "VPN" }],
+};
+
+afterEach(() => {
+  sessionStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("Development Requester selection", () => {
+  it("shows a loading state while reference data is loading", () => {
+    vi.spyOn(api, "loadReferenceData").mockReturnValue(new Promise(() => {}));
+
+    render(<App />);
+
+    expect(screen.getByText("Loading Development Requesters…")).toBeInTheDocument();
+  });
+
+  it("selects an active requester and supports changing it", async () => {
+    vi.spyOn(api, "loadReferenceData").mockResolvedValue(referenceData);
+    const user = userEvent.setup();
+    render(<App />);
+
+    await user.selectOptions(await screen.findByLabelText("Development Requester"), "1");
+    await user.click(screen.getByRole("button", { name: "Continue" }));
+
+    expect(screen.getByText("Current requester: Nicha Somchai")).toBeInTheDocument();
+    expect(screen.getByText("Reference data ready: 1 category and 1 related system.")).toBeInTheDocument();
+    expect(sessionStorage.getItem("toktickit.requesterId")).toBe("1");
+
+    await user.click(screen.getByRole("button", { name: "Change Requester" }));
+
+    expect(await screen.findByLabelText("Development Requester")).toBeInTheDocument();
+    expect(sessionStorage.getItem("toktickit.requesterId")).toBeNull();
+  });
+
+  it("shows an empty state when no active requester exists", async () => {
+    vi.spyOn(api, "loadReferenceData").mockResolvedValue({ ...referenceData, requesters: [] });
+
+    render(<App />);
+
+    expect(await screen.findByText("No active Development Requesters are available.")).toBeInTheDocument();
+  });
+
+  it("shows a retryable failure state", async () => {
+    vi.spyOn(api, "loadReferenceData")
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(referenceData);
+    const user = userEvent.setup();
+    render(<App />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to load requester and reference data.");
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(await screen.findByLabelText("Development Requester")).toBeInTheDocument();
+  });
+});

--- a/docs/lab-02/ai-use.md
+++ b/docs/lab-02/ai-use.md
@@ -10,9 +10,11 @@
   summarization can be long to cover everything. I
   prioritize organization of the summary. | Summarize and clarify things that need to be done in Lab 2 |
 | 2 | Recheck the database design and fix `specification.md` if needed. | Reviewed the Lab 2 data requirements, then added the proposed Prisma models, fields, relations, constraints, and indexes to the contract. |
+| 3 | Start Issue 13: Development Requester selection and reference data. Implement only the temporary requester context, active-only APIs, selector states, and tests. | Used the proposed scope to keep the branch limited to three reference-data endpoints, session-based requester selection, and focused API/UI tests. |
+| 4 | Test everything for the requester-context branch and check whether it is ready for a one-shot PR. | Reviewed the branch diff, ran migration/seed, server and client tests, and both builds; then identified and repaired the local PostgreSQL port mapping needed for database-backed verification. |
 
 ## Reflection
 I used AI to turn the Lab 2 handout into an initial engineering contract, then
-reviewed each decision against the handout. More specific prompts helped me
-catch and correct the ticket-number design and make the database section meet
-the required level of detail.
+reviewed each decision against the handout. For Issue 13, I used focused prompts
+to keep the work limited to requester context and reference data, and verified
+the resulting API, UI states, and local database setup myself.

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -6,21 +6,75 @@
 ## Pull Requests I authored (reviewed by my partner)
 | PR | Branch | Reviewer verdict |
 |----|--------|------------------|
-| [#17](https://github.com/jarbbie/toktickit/pull/17) | feature/5-lab2-contract | Changes requested |
+| [#17](https://github.com/jarbbie/toktickit/pull/17) | feature/5-lab2-contract | Approved |
+| [#20](https://github.com/jarbbie/toktickit/pull/20) | feature/6-db-seed | Approved |
 
-[feature/5-lab2-contract](https://github.com/jarbbie/toktickit/pull/17)
+---
+
+[#17 feature/5-lab2-contract](https://github.com/jarbbie/toktickit/pull/17)
+Reviewer:
+```
+Thanks! Please fix these 3 small things before I approve:
+
+    docs/lab-02/ai-use.md: Fill in row 2 with a real prompt you used, and replace the Reflection placeholder with 2–3 sentences about how you used AI.
+
+    docs/lab-02/reviewer.md: After this review, copy this review comment into Reviewer comment I received, then write a short How I responded note explaining the fixes you made.
+
+    docs/lab-02/specification.md (BR-03): Add one sentence saying that, if the random ticket number already exists, the server generates a new number and tries again. This prevents a rare duplicate-number error.
+
+After these changes, please request my review again I will approve.
+```
+
+Me:
+```
+Addressed in commit 4d78b91.
+
+    Filled the second AI-use prompt and replaced the reflection placeholder.
+    Recorded your review comment and my response in reviewer.md.
+    Updated BR-03 so the server regenerates and retries if a random ticket number already exists.
+
+Please re-review when convenient. Thank you.
+```
+
+Reviewer:
+```
+Approved.
+
+The requested updates are complete:
+
+    The AI-use record now has a real second prompt and reflection.
+    The peer-review record includes the review feedback and response.
+    BR-03 now requires retrying when a generated ticket number already exists.
+
+I also rechecked the final diff for whitespace errors; it passes. There are no CI checks configured on this branch.
+```
+
+---
+
+[#20 feature/6-db-seed](https://github.com/jarbbie/toktickit/pull/20)
 Reviewer comment I received:
-> Please fill in the second AI-use prompt and replace the reflection placeholder;
-> record this review comment and your response; and update BR-03 so the server
-> generates a new random Ticket Number and retries if a generated number already
-> exists.
+```
+Approved.
 
-How I responded: I added a real second prompt and reflection, recorded this
-review feedback, and updated BR-03 with the duplicate-number retry rule.
+The Lab 2 data foundation meets the required database increment:
+
+    The Prisma schema and additive migration include the required models, enums, foreign keys, unique constraints, and indexes.
+    The seed data is idempotent and includes the 4 required categories, 6 related systems, 4 active requesters, and 1 inactive requester.
+    Local upload storage is correctly ignored.
+
+I verified that Prisma schema validation passes, the new seed-data test passes, and the diff has no whitespace errors.
+```
+
+How I responded:
+```
+Thank you for approval jaa :D
+```
+
+---
 
 ## Pull Requests I reviewed for my partner
-[feature/lab2-spec](https://github.com/SupeemAFK/TokTickIT-Individual-Sprints/pull/22) by @SupeemAFK
-My comment:
+[#22 feature/lab2-spec](https://github.com/SupeemAFK/TokTickIT-Individual-Sprints/pull/22) @SupeemAFK
+Me:
 ```
 Thanks—this is a clear, well-organized Lab 2 engineering contract. The scope, API behavior, UI states, acceptance criteria, and planned test traceability are strong.
 
@@ -35,7 +89,7 @@ This is required in the contract stage by the Lab 2 sheet:
 
 The later data/requester Issue will implement the approved design in schema.prisma, migrations, seeds, and tests. Once the contract documents that design, I’m happy to approve.
 ```
-Partner's response:
+Partner:
 ```
 Addressed the requested contract change in the latest commit.
 
@@ -43,7 +97,7 @@ specification.md Section 7 now documents the proposed Prisma models, fields/type
 
 The reviewer record now also reflects this genuine request and response. Please re-review when convenient.
 ```
-My comment:
+Me:
 ```
 Approved!
 
@@ -51,3 +105,64 @@ The updated Lab 2 engineering contract now documents the required data design, i
 
 This satisfies the Lab 2 requirements in Sections 5, 5.1, 5.2, and 8.10. The specification, API contract, UI specification, and test plan are consistent and provide a clear contract for the following implementation Issues.
 ```
+
+---
+
+[#23 feature/lab2-database](https://github.com/SupeemAFK/TokTickIT-Individual-Sprints/pull/23) @SupeemAFK
+Me:
+```
+The Lab 2 schema and idempotent seed design look good. However, the new migration cannot apply to an existing Lab 1 database.
+
+Category.updatedAt is added as TIMESTAMP NOT NULL without a default value or
+backfill. Since Lab 1 already has seeded Category rows, PostgreSQL cannot create
+that required column.
+
+Please update the migration to:
+
+    Add updatedAt as nullable.
+    Backfill it from createdAt for existing rows.
+    Change it to NOT NULL.
+
+Then verify the migration works against a non-empty Lab 1 database. After that, I’m happy to approve.
+```
+
+Partner:
+```
+Addressed the migration compatibility issue in the latest commit.
+
+The migration now adds Category.updatedAt as nullable, backfills every existing row from createdAt, and then enforces NOT NULL.
+
+Verification:
+
+    Applied the Lab 1 migration to a new isolated local database.
+    Inserted two existing Category rows.
+    Applied this Lab 2 migration successfully.
+    Confirmed 2 of 2 existing rows received updatedAt equal to createdAt.
+    Full server suite: 5 tests passed; TypeScript build passed.
+
+Please re-review when convenient.
+```
+
+Me:
+```
+Approved!
+
+The migration now safely supports existing Lab 1 Category rows: it adds updatedAt as
+nullable, backfills it from createdAt, then enforces NOT NULL.
+
+I also rechecked the schema validation, server tests, and TypeScript build successfully. The database schema, idempotent seed data, migration, and seed tests are ready to merge into lab2-staging.
+```
+
+---
+
+[#24 feature/requester-context](https://github.com/SupeemAFK/TokTickIT-Individual-Sprints/pull/24) @SupeemAFK
+Me:
+```
+Approved.
+
+The Development Requester endpoint correctly returns active requesters in name order, and the selector implements loading, empty, retryable error, session-storage context, and Change Requester behavior.
+
+The UI and API test coverage matches the Lab 2 requester-selection contract. Thanks for including the verification results.
+```
+
+Partner: Noticed successfully merged PR.

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -66,6 +66,15 @@ cd client && npm test
 API-01 and UI-01 pass on the requester-context feature branch. The remaining
 tests are planned and require their later implementation branches.
 
+Requester-context verification completed on `feature/7-requester-context`:
+
+- `npx prisma migrate status` — 2 migrations found; database schema up to date.
+- `npx prisma db seed` — passed; seed remains idempotent.
+- `cd server && npm test` — 6 tests passed.
+- `cd server && npm run build` — passed.
+- `cd client && npm test` — 5 tests passed.
+- `cd client && npm run build` — passed.
+
 ## 7. Known Limitations or Deferred Tests
 
 Authentication, roles, IT Staff workflow, comments, notes, actions, and ticket

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -12,12 +12,12 @@ inactive requester.
 | ID | Type | AC | What it proves | Planned file | Final |
 |---|---|---|---|---|---|
 | UNIT-01 | Unit | AC-03 | Ticket-number generator produces `TKT-YYYY-XXXXXXXX` | `server/tests/lab-02/ticket-number.test.ts` | Planned |
-| API-01 | API | AC-01 | Active requester list omits inactive requester | `server/tests/lab-02/requesters.api.test.ts` | Planned |
+| API-01 | API | AC-01 | Active requester, Category, and Related System APIs exclude inactive data | `server/tests/lab-02/reference-data.api.test.ts` | Pass |
 | API-02 | API | AC-03, AC-04 | Valid ticket creates `NEW`; invalid fields return 400 | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
 | API-03 | API | AC-06, AC-08, AC-09 | Owned list search/filter/sort/page response is correct | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-04 | API | AC-07, AC-10 | Owned detail succeeds; cross-requester detail returns 404 | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
 | API-05 | API | AC-11, AC-12, AC-13 | Upload, size/type/count limits, removal, and blocked download | `server/tests/lab-02/attachments.api.test.ts` | Planned |
-| UI-01 | UI | AC-01, AC-02 | Selector loading, active choices, selection, and failure state | `client/tests/lab-02/RequesterSelection.test.tsx` | Planned |
+| UI-01 | UI | AC-01, AC-02 | Selector loading, empty, failure, selection, and Change Requester states | `client/tests/lab-02/RequesterSelection.test.tsx` | Pass |
 | UI-02 | UI | AC-03–AC-05 | Create form validation, busy, success, and retained failure values | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
 | UI-03 | UI | AC-06, AC-08, AC-09 | My Tickets loading, filters, pagination, empty/no-results/error states | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
 | UI-04 | UI | AC-10–AC-13 | Read-only detail and attachment action states | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
@@ -63,9 +63,8 @@ cd client && npm test
 
 ## 6. Final Results
 
-All tests are planned in this contract. Replace `Planned` with final pass/fail
-evidence only after the corresponding implementation is merged and run on
-`main`.
+API-01 and UI-01 pass on the requester-context feature branch. The remaining
+tests are planned and require their later implementation branches.
 
 ## 7. Known Limitations or Deferred Tests
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -21,12 +21,39 @@ app.get("/api/health", (_req: Request, res: Response) => {
 app.get("/api/categories", async (_req: Request, res: Response) => {
   try {
     const categories = await getPrisma().category.findMany({
+      where: { isActive: true },
       select: { id: true, name: true },
-      orderBy: { id: "asc" },
+      orderBy: { name: "asc" },
     });
     res.json(categories);
   } catch {
-    res.status(500).json({ error: "Unable to load request categories" });
+    res.status(500).json({ error: "Unable to load request categories." });
+  }
+});
+
+app.get("/api/requesters", async (_req: Request, res: Response) => {
+  try {
+    const requesters = await getPrisma().requester.findMany({
+      where: { isActive: true },
+      orderBy: { name: "asc" },
+      select: { id: true, name: true, email: true },
+    });
+    res.json(requesters);
+  } catch {
+    res.status(500).json({ error: "Unable to load requesters." });
+  }
+});
+
+app.get("/api/related-systems", async (_req: Request, res: Response) => {
+  try {
+    const relatedSystems = await getPrisma().relatedSystem.findMany({
+      where: { isActive: true },
+      orderBy: { name: "asc" },
+      select: { id: true, name: true },
+    });
+    res.json(relatedSystems);
+  } catch {
+    res.status(500).json({ error: "Unable to load related systems." });
   }
 });
 

--- a/server/tests/lab-01/categories.test.ts
+++ b/server/tests/lab-01/categories.test.ts
@@ -4,15 +4,15 @@ import { app } from "../../src/app.js";
 
 // Requires the DB to be migrated and seeded first.
 describe("GET /api/categories", () => {
-  it("returns the four seeded categories in id order", async () => {
+  it("returns the active seeded categories in name order", async () => {
     const res = await request(app).get("/api/categories");
 
     expect(res.status).toBe(200);
     expect(res.body.map((category: { name: string }) => category.name)).toEqual([
       "Account and Access",
       "Hardware",
-      "Software",
       "Network",
+      "Software",
     ]);
   });
 });

--- a/server/tests/lab-02/reference-data.api.test.ts
+++ b/server/tests/lab-02/reference-data.api.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+const prisma = vi.hoisted(() => ({
+  requester: { findMany: vi.fn() },
+  category: { findMany: vi.fn() },
+  relatedSystem: { findMany: vi.fn() },
+}));
+
+vi.mock("../../src/prisma.js", () => ({ getPrisma: () => prisma }));
+
+import { app } from "../../src/app.js";
+
+describe("Lab 2 reference-data APIs", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns active requesters ordered by name", async () => {
+    prisma.requester.findMany.mockResolvedValue([{ id: 2, name: "Anan", email: "anan@example.test" }]);
+
+    const response = await request(app).get("/api/requesters");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([{ id: 2, name: "Anan", email: "anan@example.test" }]);
+    expect(prisma.requester.findMany).toHaveBeenCalledWith({
+      where: { isActive: true }, orderBy: { name: "asc" }, select: { id: true, name: true, email: true },
+    });
+  });
+
+  it("returns only active categories and related systems ordered by name", async () => {
+    prisma.category.findMany.mockResolvedValue([{ id: 1, name: "Hardware" }]);
+    prisma.relatedSystem.findMany.mockResolvedValue([{ id: 3, name: "VPN" }]);
+
+    const [categories, relatedSystems] = await Promise.all([
+      request(app).get("/api/categories"),
+      request(app).get("/api/related-systems"),
+    ]);
+
+    expect(categories.body).toEqual([{ id: 1, name: "Hardware" }]);
+    expect(relatedSystems.body).toEqual([{ id: 3, name: "VPN" }]);
+    expect(prisma.category.findMany).toHaveBeenCalledWith({
+      where: { isActive: true }, orderBy: { name: "asc" }, select: { id: true, name: true },
+    });
+    expect(prisma.relatedSystem.findMany).toHaveBeenCalledWith({
+      where: { isActive: true }, orderBy: { name: "asc" }, select: { id: true, name: true },
+    });
+  });
+
+  it("returns a safe error when reference data cannot be loaded", async () => {
+    prisma.requester.findMany.mockRejectedValue(new Error("database unavailable"));
+
+    const response = await request(app).get("/api/requesters");
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: "Unable to load requesters." });
+  });
+});


### PR DESCRIPTION
## Summary
- add active-only requester, Category, and Related System APIs
- add the temporary Development Requester selector with loading, empty, retry, persistence, and Change Requester behavior
- record Issue 13 test and AI-use evidence

## Verification
- Prisma migration status and idempotent seed passed
- Server tests: 6 passed; server build passed
- Client tests: 5 passed; client build passed

Closes #13