### PR TITLE
feat: add Ticket creation API

### DIFF
--- a/docs/lab-02/ai-use.md
+++ b/docs/lab-02/ai-use.md
@@ -12,9 +12,11 @@
 | 2 | Recheck the database design and fix `specification.md` if needed. | Reviewed the Lab 2 data requirements, then added the proposed Prisma models, fields, relations, constraints, and indexes to the contract. |
 | 3 | Start Issue 13: Development Requester selection and reference data. Implement only the temporary requester context, active-only APIs, selector states, and tests. | Used the proposed scope to keep the branch limited to three reference-data endpoints, session-based requester selection, and focused API/UI tests. |
 | 4 | Test everything for the requester-context branch and check whether it is ready for a one-shot PR. | Reviewed the branch diff, ran migration/seed, server and client tests, and both builds; then identified and repaired the local PostgreSQL port mapping needed for database-backed verification. |
+| 5 | PR #21 already merged, maybe move to next issue. | Updated the staging branch, created the Ticket creation API branch, and reviewed the approved contract before writing focused tests. |
+| 6 | Add 1-2 more prompt to ai-use.md; check if tests.md have to update. | Checked the test-plan traceability, confirmed the Unit and Ticket API results were already recorded, then added this AI-use evidence. |
 
 ## Reflection
 I used AI to turn the Lab 2 handout into an initial engineering contract, then
-reviewed each decision against the handout. For Issue 13, I used focused prompts
-to keep the work limited to requester context and reference data, and verified
-the resulting API, UI states, and local database setup myself.
+reviewed each decision against the handout. For Issues 13 and 14, I used focused
+prompts to keep each branch limited to its requester-context or Ticket API scope,
+then verified the API behavior, UI states, tests, and local database setup myself.

--- a/docs/lab-02/reviewer.md
+++ b/docs/lab-02/reviewer.md
@@ -8,6 +8,7 @@
 |----|--------|------------------|
 | [#17](https://github.com/jarbbie/toktickit/pull/17) | feature/5-lab2-contract | Approved |
 | [#20](https://github.com/jarbbie/toktickit/pull/20) | feature/6-db-seed | Approved |
+| [#21](https://github.com/jarbbie/toktickit/pull/21) | feature/7-requester-context | Approved |
 
 ---
 
@@ -69,6 +70,27 @@ How I responded:
 ```
 Thank you for approval jaa :D
 ```
+
+---
+
+[#21 feature/7-requester-context](https://github.com/jarbbie/toktickit/pull/21)
+Reviewer:
+```
+Approved.
+
+The requester context implementation meets the Lab 2 requirement for a temporary,
+non-authentication requester selector:
+
+- Active requesters, categories, and related systems are returned in name order.
+- The selector handles loading, empty, retry, persistence, and Change Requester states.
+- The new API and UI tests cover the new behavior.
+
+I verified the client test suite and production build pass, and the diff has no
+whitespace errors. No CI checks are configured on this branch.
+```
+
+How I responded: No changes were requested. The PR was merged into
+`lab2-staging` after approval.
 
 ---
 
@@ -166,3 +188,74 @@ The UI and API test coverage matches the Lab 2 requester-selection contract. Tha
 ```
 
 Partner: Noticed successfully merged PR.
+
+---
+
+[#25 feature/create-ticket-api](https://github.com/SupeemAFK/TokTickIT-Individual-Sprints/pull/25) @SupeemAFK
+Me:
+```
+Request changes:
+
+docs/lab-02/tests.md marks API-02 as Pass, but its Final Results section still
+says "Not run: this is the pre-implementation plan." Please update that section
+to record the passing API test while keeping the remaining planned tests pending.
+```
+
+Partner:
+```
+Addressed the requested documentation correction in the latest commit. The Final
+Results section now records the passing API-01, UI-01, and API-02 coverage and
+explicitly leaves all remaining rows Planned. Verification remains green: server
+10 tests, client 9 tests, and both TypeScript builds pass.
+```
+
+Me:
+```
+Request changes: malformed JSON sent to POST /api/tickets returns Express's
+default HTML error page with a stack trace and server paths, rather than the
+documented safe JSON error. Please add an express.json() parse-error handler
+returning a safe 400 JSON response and cover it with a test.
+```
+
+Partner:
+```
+Addressed the malformed-JSON request. express.json() parse failures now return
+400 with a safe JSON error and no HTML stack trace or server paths. Added focused
+API coverage. The Create Ticket API tests, full server suite, and server
+TypeScript build pass.
+```
+
+Me:
+```
+Approved. The malformed-JSON error is now a safe JSON 400 response and is
+covered by an API test.
+```
+
+---
+
+[#26 feature/create-ticket-ui](https://github.com/SupeemAFK/TokTickIT-Individual-Sprints/pull/26) @SupeemAFK
+Me:
+```
+Request changes:
+
+1. The three read-only system fields need the distinct read-only visual treatment
+required by ui-spec.md, not only the readOnly attribute.
+2. Please add the missing busy/disabled duplicate-submission test before marking
+UI-02 Pass.
+```
+
+Partner:
+```
+Addressed both requested changes. The Requester, Ticket Date, and Ticket Number
+fields now use the distinct pale gray-green read-only treatment. Added a
+regression test that keeps submission pending, verifies the busy label and
+disabled button, attempts a second click, and confirms only one API request
+occurs. The Create Ticket UI, full client and server suites, and both builds pass.
+```
+
+Me:
+```
+Approved. The required read-only treatment is now applied, and the new
+deferred-request test verifies the busy/disabled state prevents duplicate
+submission.
+```

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -11,9 +11,9 @@ inactive requester.
 
 | ID | Type | AC | What it proves | Planned file | Final |
 |---|---|---|---|---|---|
-| UNIT-01 | Unit | AC-03 | Ticket-number generator produces `TKT-YYYY-XXXXXXXX` | `server/tests/lab-02/ticket-number.test.ts` | Planned |
+| UNIT-01 | Unit | AC-03 | Ticket-number generator produces `TKT-YYYY-XXXXXXXX` | `server/tests/lab-02/ticket-number.test.ts` | Pass |
 | API-01 | API | AC-01 | Active requester, Category, and Related System APIs exclude inactive data | `server/tests/lab-02/reference-data.api.test.ts` | Pass |
-| API-02 | API | AC-03, AC-04 | Valid ticket creates `NEW`; invalid fields return 400 | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
+| API-02 | API | AC-03, AC-04 | Valid ticket creates `NEW`; validation, inactive references, duplicate retry, and malformed JSON return safe responses | `server/tests/lab-02/create-ticket.api.test.ts` | Pass |
 | API-03 | API | AC-06, AC-08, AC-09 | Owned list search/filter/sort/page response is correct | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | API-04 | API | AC-07, AC-10 | Owned detail succeeds; cross-requester detail returns 404 | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
 | API-05 | API | AC-11, AC-12, AC-13 | Upload, size/type/count limits, removal, and blocked download | `server/tests/lab-02/attachments.api.test.ts` | Planned |
@@ -71,6 +71,15 @@ Requester-context verification completed on `feature/7-requester-context`:
 - `npx prisma migrate status` — 2 migrations found; database schema up to date.
 - `npx prisma db seed` — passed; seed remains idempotent.
 - `cd server && npm test` — 6 tests passed.
+- `cd server && npm run build` — passed.
+- `cd client && npm test` — 5 tests passed.
+- `cd client && npm run build` — passed.
+
+Ticket-creation API verification completed on `feature/8-ticket-create-api`:
+
+- `npx prisma migrate status` — 2 migrations found; database schema up to date.
+- `npx prisma db seed` — passed; seed remains idempotent.
+- `cd server && npm test` — 17 tests passed.
 - `cd server && npm run build` — passed.
 - `cd client && npm test` — 5 tests passed.
 - `cd client && npm run build` — passed.

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,6 +1,35 @@
-import express, { Request, Response } from "express";
+import express, { NextFunction, Request, Response } from "express";
 import cors from "cors";
 import { getPrisma } from "./prisma.js";
+import { generateTicketNumber } from "./ticket-number.js";
+
+const priorities = ["LOW", "MEDIUM", "HIGH", "URGENT"] as const;
+
+class RequestError extends Error {
+  constructor(readonly message: string) { super(message); }
+}
+
+function requiredId(value: unknown, name: string) {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+    throw new RequestError(`${name} must be a positive integer.`);
+  }
+  return value;
+}
+
+function requiredText(value: unknown, name: string, min: number, max: number) {
+  if (typeof value !== "string") throw new RequestError(`${name} is required.`);
+  const text = value.trim();
+  if (text.length < min || text.length > max) throw new RequestError(`${name} must be between ${min} and ${max} characters.`);
+  return text;
+}
+
+function requestedPriority(value: unknown) {
+  if (value === undefined) return "MEDIUM";
+  if (typeof value !== "string" || !priorities.includes(value as typeof priorities[number])) {
+    throw new RequestError("requestedPriority must be LOW, MEDIUM, HIGH, or URGENT.");
+  }
+  return value as typeof priorities[number];
+}
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -8,6 +37,13 @@ export const app = express();
 
 app.use(cors());          // already wired: lets the Vite dev server call this API
 app.use(express.json());
+app.use((error: Error & { type?: string }, _req: Request, res: Response, next: NextFunction) => {
+  if (error.type === "entity.parse.failed") {
+    res.status(400).json({ error: "Malformed JSON request body." });
+    return;
+  }
+  next(error);
+});
 
 // ---------------------------------------------------------------------------
 // Issue 2 — API health check
@@ -54,6 +90,46 @@ app.get("/api/related-systems", async (_req: Request, res: Response) => {
     res.json(relatedSystems);
   } catch {
     res.status(500).json({ error: "Unable to load related systems." });
+  }
+});
+
+app.post("/api/tickets", async (req: Request, res: Response) => {
+  try {
+    const requesterId = requiredId(req.body?.requesterId, "requesterId");
+    const categoryId = requiredId(req.body?.categoryId, "categoryId");
+    const relatedSystemId = requiredId(req.body?.relatedSystemId, "relatedSystemId");
+    const summary = requiredText(req.body?.summary, "summary", 5, 200);
+    const description = requiredText(req.body?.description, "description", 10, 4_000);
+    const priority = requestedPriority(req.body?.requestedPriority);
+    const prisma = getPrisma();
+    const [requester, category, relatedSystem] = await Promise.all([
+      prisma.requester.findFirst({ where: { id: requesterId, isActive: true }, select: { id: true } }),
+      prisma.category.findFirst({ where: { id: categoryId, isActive: true }, select: { id: true } }),
+      prisma.relatedSystem.findFirst({ where: { id: relatedSystemId, isActive: true }, select: { id: true } }),
+    ]);
+
+    if (!requester || !category || !relatedSystem) throw new RequestError("Requester or reference data is unavailable.");
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        const ticket = await prisma.ticket.create({
+          data: {
+            ticketNumber: generateTicketNumber(), requesterId, categoryId, relatedSystemId,
+            requestedPriority: priority, status: "NEW", summary, description,
+          },
+        });
+        res.status(201).json(ticket);
+        return;
+      } catch (error) {
+        if (!(typeof error === "object" && error !== null && "code" in error && error.code === "P2002") || attempt === 2) throw error;
+      }
+    }
+  } catch (error) {
+    if (error instanceof RequestError) {
+      res.status(400).json({ error: error.message });
+      return;
+    }
+    res.status(500).json({ error: "Unable to create ticket." });
   }
 });
 

--- a/server/src/ticket-number.ts
+++ b/server/src/ticket-number.ts
@@ -1,0 +1,5 @@
+import { randomBytes } from "node:crypto";
+
+export function generateTicketNumber(date = new Date()) {
+  return `TKT-${date.getUTCFullYear()}-${randomBytes(4).toString("hex").toUpperCase()}`;
+}

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+const prisma = vi.hoisted(() => ({
+  requester: { findFirst: vi.fn() },
+  category: { findFirst: vi.fn() },
+  relatedSystem: { findFirst: vi.fn() },
+  ticket: { create: vi.fn() },
+}));
+
+vi.mock("../../src/prisma.js", () => ({ getPrisma: () => prisma }));
+
+import { app } from "../../src/app.js";
+
+const validTicket = {
+  requesterId: 1,
+  categoryId: 2,
+  relatedSystemId: 3,
+  summary: "  VPN cannot connect  ",
+  description: "  The VPN fails after entering my university credentials.  ",
+};
+
+function mockActiveReferences() {
+  prisma.requester.findFirst.mockResolvedValue({ id: 1 });
+  prisma.category.findFirst.mockResolvedValue({ id: 2 });
+  prisma.relatedSystem.findFirst.mockResolvedValue({ id: 3 });
+}
+
+describe("POST /api/tickets", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("creates a trimmed New ticket with a backend ticket number and default priority", async () => {
+    mockActiveReferences();
+    prisma.ticket.create.mockResolvedValue({
+      id: 1, ticketNumber: "TKT-2026-A1B2C3D4", requesterId: 1, categoryId: 2, relatedSystemId: 3,
+      requestedPriority: "MEDIUM", status: "NEW", summary: "VPN cannot connect",
+      description: "The VPN fails after entering my university credentials.",
+    });
+
+    const response = await request(app).post("/api/tickets").send(validTicket);
+
+    expect(response.status).toBe(201);
+    expect(response.body).toMatchObject({ ticketNumber: "TKT-2026-A1B2C3D4", requesterId: 1, status: "NEW", requestedPriority: "MEDIUM" });
+    expect(prisma.ticket.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({
+      requesterId: 1, categoryId: 2, relatedSystemId: 3, summary: "VPN cannot connect",
+      description: "The VPN fails after entering my university credentials.", requestedPriority: "MEDIUM", status: "NEW",
+    }) }));
+  });
+
+  it.each([
+    ["requesterId", { requesterId: 0 }, "requesterId must be a positive integer."],
+    ["categoryId", { categoryId: 0 }, "categoryId must be a positive integer."],
+    ["relatedSystemId", { relatedSystemId: 0 }, "relatedSystemId must be a positive integer."],
+    ["summary", { summary: "bad" }, "summary must be between 5 and 200 characters."],
+    ["description", { description: "bad" }, "description must be between 10 and 4000 characters."],
+    ["requestedPriority", { requestedPriority: "NOW" }, "requestedPriority must be LOW, MEDIUM, HIGH, or URGENT."],
+  ])("rejects invalid %s without storing a ticket", async (_field, invalidValue, error) => {
+    const response = await request(app).post("/api/tickets").send({ ...validTicket, ...invalidValue });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error });
+    expect(prisma.ticket.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects inactive or missing references without storing a ticket", async () => {
+    prisma.requester.findFirst.mockResolvedValue(null);
+    prisma.category.findFirst.mockResolvedValue({ id: 2 });
+    prisma.relatedSystem.findFirst.mockResolvedValue({ id: 3 });
+
+    const response = await request(app).post("/api/tickets").send(validTicket);
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: "Requester or reference data is unavailable." });
+    expect(prisma.ticket.create).not.toHaveBeenCalled();
+  });
+
+  it("returns a safe JSON error for malformed JSON", async () => {
+    const response = await request(app).post("/api/tickets").set("Content-Type", "application/json").send('{');
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: "Malformed JSON request body." });
+  });
+
+  it("retries a duplicate ticket number", async () => {
+    mockActiveReferences();
+    prisma.ticket.create
+      .mockRejectedValueOnce({ code: "P2002" })
+      .mockResolvedValueOnce({ id: 1, ticketNumber: "TKT-2026-A1B2C3D4", status: "NEW" });
+
+    const response = await request(app).post("/api/tickets").send(validTicket);
+
+    expect(response.status).toBe(201);
+    expect(prisma.ticket.create).toHaveBeenCalledTimes(2);
+  });
+});

--- a/server/tests/lab-02/ticket-number.test.ts
+++ b/server/tests/lab-02/ticket-number.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { generateTicketNumber } from "../../src/ticket-number.js";
+
+describe("generateTicketNumber", () => {
+  it("creates the documented ticket-number format", () => {
+    expect(generateTicketNumber(new Date("2026-08-25T00:00:00.000Z"))).toMatch(/^TKT-2026-[A-F0-9]{8}$/);
+  });
+});


### PR DESCRIPTION
## Summary
- add POST /api/tickets with validation, trimming, active-reference checks, and MEDIUM priority default
- generate unique backend Ticket Numbers, retry collisions, and set NEW status
- return safe JSON errors, including malformed JSON requests
- add Ticket-number and Create Ticket API tests with updated Lab 2 evidence

## Verification
- Prisma migration status and idempotent seed passed
- Server tests: 17 passed; server build passed
- Client tests: 5 passed; client build passed

Relates to #14