### PR TITLE
feat: add create ticket UI

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "bootstrap": "^5.3.3",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.30.6"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -978,6 +979,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.4",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
+      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2707,6 +2717,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
+      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.6",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
+      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.4",
+        "react-router": "6.30.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/redent": {

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "bootstrap": "^5.3.3",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.30.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from "react";
-import { type ReferenceData, loadReferenceData } from "./api.js";
+import { type FormEvent, type ReactNode, useEffect, useState } from "react";
+import { NavLink, Navigate, Route, Routes, useNavigate } from "react-router-dom";
+import { type CreatedTicket, type ReferenceData, type Requester, createTicket, loadReferenceData } from "./api.js";
 
 type LoadState = "loading" | "ready" | "error";
+type FormValues = { categoryId: string; relatedSystemId: string; requestedPriority: "LOW" | "MEDIUM" | "HIGH" | "URGENT"; summary: string; description: string };
 const requesterStorageKey = "toktickit.requesterId";
 
 function savedRequesterId() {
@@ -9,11 +11,122 @@ function savedRequesterId() {
   return Number.isInteger(id) && id > 0 ? id : null;
 }
 
+function Shell({ requester, onChangeRequester, children }: { requester: Requester; onChangeRequester: () => void; children: ReactNode }) {
+  return (
+    <main className="min-vh-100" style={{ backgroundColor: "#F5F7F6" }}>
+      <header className="border-bottom bg-white">
+        <div className="container py-3 d-flex flex-wrap align-items-center gap-3" style={{ maxWidth: 1100 }}>
+          <strong style={{ color: "#006B3C" }}>TokTickIT</strong>
+          <nav className="d-flex gap-3" aria-label="Main navigation">
+            <NavLink className={({ isActive }) => isActive ? "fw-semibold text-success text-decoration-underline" : "text-decoration-none"} to="/tickets">My Tickets</NavLink>
+            <NavLink className={({ isActive }) => isActive ? "fw-semibold text-success text-decoration-underline" : "text-decoration-none"} to="/tickets/new">Create Ticket</NavLink>
+          </nav>
+          <span className="ms-md-auto">Requester: {requester.name}</span>
+          <button className="btn btn-sm btn-outline-success" onClick={onChangeRequester}>Change Requester</button>
+        </div>
+      </header>
+      <div className="container py-5" style={{ maxWidth: 900 }}>{children}</div>
+    </main>
+  );
+}
+
+function RequesterSelector({ data, onSelected }: { data: ReferenceData; onSelected: (id: number) => void }) {
+  const [pendingId, setPendingId] = useState<number | null>(null);
+  const navigate = useNavigate();
+
+  if (data.requesters.length === 0) return <main className="container py-5"><h1 className="h3" style={{ color: "#006B3C" }}>TokTickIT</h1><div className="alert alert-warning mt-4" role="status">No active Development Requesters are available.</div></main>;
+
+  function continueWithRequester() {
+    if (!pendingId) return;
+    onSelected(pendingId);
+    navigate("/tickets");
+  }
+
+  return (
+    <main className="container py-5" style={{ maxWidth: 640 }}>
+      <header className="mb-4"><h1 className="h3 mb-1" style={{ color: "#006B3C" }}>TokTickIT</h1><p className="text-secondary mb-0">IT Service Desk</p></header>
+      <section className="card shadow-sm"><div className="card-body">
+        <h2 className="h4">Select Development Requester</h2>
+        <p>This selector is for Lab 2 testing only. It is not a login screen.</p>
+        <label className="form-label fw-semibold" htmlFor="requester">Development Requester</label>
+        <select className="form-select mb-3" id="requester" value={pendingId ?? ""} onChange={(event) => setPendingId(Number(event.target.value) || null)}>
+          <option value="">Choose a requester</option>
+          {data.requesters.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}
+        </select>
+        <button className="btn text-white" style={{ backgroundColor: "#006B3C" }} disabled={!pendingId} onClick={continueWithRequester}>Continue</button>
+      </div></section>
+    </main>
+  );
+}
+
+function CreateTicket({ requester, data }: { requester: Requester; data: ReferenceData }) {
+  const [form, setForm] = useState<FormValues>({ categoryId: "", relatedSystemId: "", requestedPriority: "MEDIUM", summary: "", description: "" });
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [failure, setFailure] = useState("");
+  const [created, setCreated] = useState<CreatedTicket | null>(null);
+
+  function update<K extends keyof FormValues>(key: K, value: FormValues[K]) {
+    setForm((current) => ({ ...current, [key]: value }));
+    setErrors((current) => ({ ...current, [key]: "" }));
+  }
+
+  function validate() {
+    const next: Record<string, string> = {};
+    if (!form.categoryId) next.categoryId = "Category is required.";
+    if (!form.relatedSystemId) next.relatedSystemId = "Related System is required.";
+    if (form.summary.trim().length < 5 || form.summary.trim().length > 200) next.summary = "Ticket Summary must be between 5 and 200 characters.";
+    if (form.description.trim().length < 10 || form.description.trim().length > 4000) next.description = "Description must be between 10 and 4000 characters.";
+    return next;
+  }
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    const nextErrors = validate();
+    setErrors(nextErrors);
+    setFailure("");
+    if (Object.keys(nextErrors).length > 0) return;
+    setSubmitting(true);
+    try {
+      setCreated(await createTicket({ requesterId: requester.id, categoryId: Number(form.categoryId), relatedSystemId: Number(form.relatedSystemId), requestedPriority: form.requestedPriority, summary: form.summary, description: form.description }));
+    } catch (error) {
+      setFailure(error instanceof Error ? error.message : "Unable to create ticket.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (created) return <section className="card shadow-sm"><div className="card-body"><h1 className="h3">Ticket created: {created.ticketNumber}</h1><p>Your ticket is saved with status New.</p><NavLink className="btn text-white" style={{ backgroundColor: "#006B3C" }} to="/tickets">View My Tickets</NavLink></div></section>;
+
+  const invalid = (name: string) => errors[name] ? "form-control is-invalid" : "form-control";
+  const invalidSelect = (name: string) => errors[name] ? "form-select is-invalid" : "form-select";
+  return (
+    <section className="card shadow-sm"><div className="card-body">
+      <h1 className="h3 mb-4">Create Ticket</h1>
+      {failure && <div className="alert alert-danger" role="alert">{failure}</div>}
+      <form noValidate onSubmit={submit}>
+        <div className="row g-3 mb-3">
+          <div className="col-md-4"><label className="form-label" htmlFor="ticket-requester">Requester</label><input className="form-control" id="ticket-requester" readOnly value={requester.name} style={{ backgroundColor: "#EAF6EF" }} /></div>
+          <div className="col-md-4"><label className="form-label" htmlFor="ticket-date">Ticket Date</label><input className="form-control" id="ticket-date" readOnly value="Generated on submission" style={{ backgroundColor: "#EAF6EF" }} /></div>
+          <div className="col-md-4"><label className="form-label" htmlFor="ticket-number">Ticket Number</label><input className="form-control" id="ticket-number" readOnly value="Generated after submission" style={{ backgroundColor: "#EAF6EF" }} /></div>
+        </div>
+        <div className="row g-3">
+          <div className="col-md-6"><label className="form-label" htmlFor="category">Category <span className="text-danger">*</span></label><select className={invalidSelect("categoryId")} id="category" value={form.categoryId} onChange={(event) => update("categoryId", event.target.value)}><option value="">Choose a category</option>{data.categories.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}</select>{errors.categoryId && <div className="invalid-feedback">{errors.categoryId}</div>}</div>
+          <div className="col-md-6"><label className="form-label" htmlFor="related-system">Related System <span className="text-danger">*</span></label><select className={invalidSelect("relatedSystemId")} id="related-system" value={form.relatedSystemId} onChange={(event) => update("relatedSystemId", event.target.value)}><option value="">Choose a related system</option>{data.relatedSystems.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}</select>{errors.relatedSystemId && <div className="invalid-feedback">{errors.relatedSystemId}</div>}</div>
+          <div className="col-md-6"><label className="form-label" htmlFor="requested-priority">Requested Priority <span className="text-danger">*</span></label><select className="form-select" id="requested-priority" value={form.requestedPriority} onChange={(event) => update("requestedPriority", event.target.value as FormValues["requestedPriority"])}>{["LOW", "MEDIUM", "HIGH", "URGENT"].map((priority) => <option key={priority}>{priority}</option>)}</select></div>
+          <div className="col-12"><label className="form-label" htmlFor="summary">Ticket Summary <span className="text-danger">*</span></label><input className={invalid("summary")} id="summary" value={form.summary} onChange={(event) => update("summary", event.target.value)} />{errors.summary && <div className="invalid-feedback">{errors.summary}</div>}</div>
+          <div className="col-12"><label className="form-label" htmlFor="description">Description <span className={"text-danger"}>*</span></label><textarea className={invalid("description")} id="description" rows={5} value={form.description} onChange={(event) => update("description", event.target.value)} />{errors.description && <div className="invalid-feedback">{errors.description}</div>}</div>
+        </div>
+        <button className="btn text-white mt-4" style={{ backgroundColor: "#006B3C" }} disabled={submitting} type="submit">{submitting ? "Submitting…" : "Submit Ticket"}</button>
+      </form>
+    </div></section>
+  );
+}
+
 export default function App() {
   const [state, setState] = useState<LoadState>("loading");
   const [referenceData, setReferenceData] = useState<ReferenceData | null>(null);
   const [requesterId, setRequesterId] = useState<number | null>(savedRequesterId);
-  const [pendingRequesterId, setPendingRequesterId] = useState<number | null>(null);
 
   async function load() {
     setState("loading");
@@ -29,64 +142,18 @@ export default function App() {
 
   useEffect(() => { void load(); }, []);
 
-  const requester = referenceData?.requesters.find((item) => item.id === requesterId);
+  if (state === "loading") return <main className="container py-5"><p role="status">Loading Development Requesters…</p></main>;
+  if (state === "error") return <main className="container py-5"><div className="alert alert-danger" role="alert"><p>Unable to load requester and reference data.</p><button className="btn btn-danger" onClick={load}>Retry</button></div></main>;
+  if (!referenceData) return null;
 
-  function continueWithRequester() {
-    if (!pendingRequesterId) return;
-    setRequesterId(pendingRequesterId);
-    sessionStorage.setItem(requesterStorageKey, String(pendingRequesterId));
-  }
+  const requester = referenceData.requesters.find((item) => item.id === requesterId);
+  if (!requester) return <Routes><Route path="/select" element={<RequesterSelector data={referenceData} onSelected={(id) => { sessionStorage.setItem(requesterStorageKey, String(id)); setRequesterId(id); }} />} /><Route path="*" element={<Navigate replace to="/select" />} /></Routes>;
 
-  function changeRequester() {
-    sessionStorage.removeItem(requesterStorageKey);
-    setRequesterId(null);
-    setPendingRequesterId(null);
-  }
-
-  return (
-    <main className="container py-5" style={{ maxWidth: 640 }}>
-      <header className="mb-4">
-        <h1 className="h3 mb-1" style={{ color: "#006B3C" }}>TokTickIT</h1>
-        <p className="text-secondary mb-0">IT Service Desk</p>
-      </header>
-
-      {state === "loading" && <p role="status">Loading Development Requesters…</p>}
-
-      {state === "error" && (
-        <div className="alert alert-danger" role="alert">
-          <p className="mb-3">Unable to load requester and reference data.</p>
-          <button className="btn btn-danger" onClick={load}>Retry</button>
-        </div>
-      )}
-
-      {state === "ready" && !requester && referenceData?.requesters.length === 0 && (
-        <div className="alert alert-warning" role="status">No active Development Requesters are available.</div>
-      )}
-
-      {state === "ready" && !requester && referenceData && referenceData.requesters.length > 0 && (
-        <section className="card shadow-sm">
-          <div className="card-body">
-            <h2 className="h4">Select Development Requester</h2>
-            <p>This selector is for Lab 2 testing only. It is not a login screen.</p>
-            <label className="form-label fw-semibold" htmlFor="requester">Development Requester</label>
-            <select className="form-select mb-3" id="requester" value={pendingRequesterId ?? ""} onChange={(event) => setPendingRequesterId(Number(event.target.value) || null)}>
-              <option value="">Choose a requester</option>
-              {referenceData.requesters.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}
-            </select>
-            <button className="btn text-white" style={{ backgroundColor: "#006B3C" }} disabled={!pendingRequesterId} onClick={continueWithRequester}>Continue</button>
-          </div>
-        </section>
-      )}
-
-      {state === "ready" && requester && referenceData && (
-        <section className="card shadow-sm" style={{ borderColor: "#EAF6EF" }}>
-          <div className="card-body">
-            <p className="fw-semibold mb-2">Current requester: {requester.name}</p>
-            <p>Reference data ready: {referenceData.categories.length} {referenceData.categories.length === 1 ? "category" : "categories"} and {referenceData.relatedSystems.length} {referenceData.relatedSystems.length === 1 ? "related system" : "related systems"}.</p>
-            <button className="btn btn-outline-success" onClick={changeRequester}>Change Requester</button>
-          </div>
-        </section>
-      )}
-    </main>
-  );
+  const changeRequester = () => { sessionStorage.removeItem(requesterStorageKey); setRequesterId(null); };
+  return <Routes>
+    <Route path="/select" element={<Navigate replace to="/tickets" />} />
+    <Route path="/tickets" element={<Shell requester={requester} onChangeRequester={changeRequester}><h1 className="h3">My Tickets</h1><p className="text-secondary">Ticket listing will be added in the next issue.</p></Shell>} />
+    <Route path="/tickets/new" element={<Shell requester={requester} onChangeRequester={changeRequester}><CreateTicket requester={requester} data={referenceData} /></Shell>} />
+    <Route path="*" element={<Navigate replace to="/tickets" />} />
+  </Routes>;
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -15,6 +15,21 @@ export interface ReferenceData {
   relatedSystems: ReferenceItem[];
 }
 
+export interface TicketInput {
+  requesterId: number;
+  categoryId: number;
+  relatedSystemId: number;
+  requestedPriority: "LOW" | "MEDIUM" | "HIGH" | "URGENT";
+  summary: string;
+  description: string;
+}
+
+export interface CreatedTicket {
+  id: number;
+  ticketNumber: string;
+  status: "NEW";
+}
+
 async function loadJson<T>(path: string): Promise<T> {
   const response = await fetch(`${API_URL}${path}`);
   if (!response.ok) throw new Error("Reference data request failed");
@@ -29,4 +44,15 @@ export async function loadReferenceData(): Promise<ReferenceData> {
   ]);
 
   return { requesters, categories, relatedSystems };
+}
+
+export async function createTicket(ticket: TicketInput): Promise<CreatedTicket> {
+  const response = await fetch(`${API_URL}/api/tickets`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(ticket),
+  });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(typeof body.error === "string" ? body.error : "Unable to create ticket.");
+  return body as CreatedTicket;
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "bootstrap/dist/css/bootstrap.min.css";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App.js";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter><App /></BrowserRouter>
   </React.StrictMode>
 );

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import App from "../../src/App.js";
 import * as api from "../../src/api.js";
 
@@ -8,9 +9,9 @@ afterEach(() => vi.restoreAllMocks());
 describe("App", () => {
   it("renders the TokTickIT heading", async () => {
     vi.spyOn(api, "loadReferenceData").mockResolvedValue({ requesters: [], categories: [], relatedSystems: [] });
-    render(<App />);
+    render(<MemoryRouter initialEntries={["/select"]}><App /></MemoryRouter>);
 
-    expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
+    expect(await screen.findByText(/TokTickIT/i)).toBeInTheDocument();
     expect(await screen.findByText("No active Development Requesters are available.")).toBeInTheDocument();
   });
 });

--- a/client/tests/lab-02/CreateTicket.test.tsx
+++ b/client/tests/lab-02/CreateTicket.test.tsx
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import App from "../../src/App.js";
+import * as api from "../../src/api.js";
+
+const referenceData = {
+  requesters: [{ id: 1, name: "Nicha Somchai", email: "nicha@example.test" }],
+  categories: [{ id: 2, name: "Hardware" }],
+  relatedSystems: [{ id: 3, name: "VPN" }],
+};
+
+function renderCreateTicket() {
+  sessionStorage.setItem("toktickit.requesterId", "1");
+  return render(<MemoryRouter initialEntries={["/tickets/new"]}><App /></MemoryRouter>);
+}
+
+async function fillValidForm(user: ReturnType<typeof userEvent.setup>) {
+  await user.selectOptions(await screen.findByLabelText(/Category/), "2");
+  await user.selectOptions(screen.getByLabelText(/Related System/), "3");
+  await user.type(screen.getByLabelText(/Ticket Summary/), "VPN cannot connect");
+  await user.type(screen.getByLabelText(/Description/), "The VPN fails after entering my university credentials.");
+}
+
+afterEach(() => {
+  sessionStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("Create Ticket", () => {
+  it("shows field validation without calling the API", async () => {
+    vi.spyOn(api, "loadReferenceData").mockResolvedValue(referenceData);
+    const createTicket = vi.spyOn(api, "createTicket");
+    const user = userEvent.setup();
+    renderCreateTicket();
+
+    await user.click(await screen.findByRole("button", { name: "Submit Ticket" }));
+
+    expect(await screen.findByText("Category is required.")).toBeInTheDocument();
+    expect(createTicket).not.toHaveBeenCalled();
+  });
+
+  it("shows a busy disabled submit button while saving", async () => {
+    vi.spyOn(api, "loadReferenceData").mockResolvedValue(referenceData);
+    vi.spyOn(api, "createTicket").mockReturnValue(new Promise(() => {}));
+    const user = userEvent.setup();
+    renderCreateTicket();
+
+    await fillValidForm(user);
+    await user.click(screen.getByRole("button", { name: "Submit Ticket" }));
+
+    expect(screen.getByRole("button", { name: "Submitting…" })).toBeDisabled();
+  });
+
+  it("shows the generated ticket number after a successful submission", async () => {
+    vi.spyOn(api, "loadReferenceData").mockResolvedValue(referenceData);
+    vi.spyOn(api, "createTicket").mockResolvedValue({ id: 1, ticketNumber: "TKT-2026-A1B2C3D4", status: "NEW" });
+    const user = userEvent.setup();
+    renderCreateTicket();
+
+    await fillValidForm(user);
+    await user.click(screen.getByRole("button", { name: "Submit Ticket" }));
+
+    expect(await screen.findByText("Ticket created: TKT-2026-A1B2C3D4")).toBeInTheDocument();
+  });
+
+  it("keeps entered values after a safe API failure", async () => {
+    vi.spyOn(api, "loadReferenceData").mockResolvedValue(referenceData);
+    vi.spyOn(api, "createTicket").mockRejectedValue(new Error("Unable to create ticket."));
+    const user = userEvent.setup();
+    renderCreateTicket();
+
+    await fillValidForm(user);
+    await user.click(screen.getByRole("button", { name: "Submit Ticket" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to create ticket.");
+    expect(screen.getByLabelText(/Ticket Summary/)).toHaveValue("VPN cannot connect");
+  });
+});

--- a/client/tests/lab-02/RequesterSelection.test.tsx
+++ b/client/tests/lab-02/RequesterSelection.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
 import App from "../../src/App.js";
 import * as api from "../../src/api.js";
 
@@ -15,11 +16,15 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+function renderApp(path = "/select") {
+  return render(<MemoryRouter initialEntries={[path]}><App /></MemoryRouter>);
+}
+
 describe("Development Requester selection", () => {
   it("shows a loading state while reference data is loading", () => {
     vi.spyOn(api, "loadReferenceData").mockReturnValue(new Promise(() => {}));
 
-    render(<App />);
+    renderApp();
 
     expect(screen.getByText("Loading Development Requesters…")).toBeInTheDocument();
   });
@@ -27,13 +32,13 @@ describe("Development Requester selection", () => {
   it("selects an active requester and supports changing it", async () => {
     vi.spyOn(api, "loadReferenceData").mockResolvedValue(referenceData);
     const user = userEvent.setup();
-    render(<App />);
+    renderApp();
 
     await user.selectOptions(await screen.findByLabelText("Development Requester"), "1");
     await user.click(screen.getByRole("button", { name: "Continue" }));
 
-    expect(screen.getByText("Current requester: Nicha Somchai")).toBeInTheDocument();
-    expect(screen.getByText("Reference data ready: 1 category and 1 related system.")).toBeInTheDocument();
+    expect(screen.getByText("Requester: Nicha Somchai")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "My Tickets" })).toBeInTheDocument();
     expect(sessionStorage.getItem("toktickit.requesterId")).toBe("1");
 
     await user.click(screen.getByRole("button", { name: "Change Requester" }));
@@ -45,7 +50,7 @@ describe("Development Requester selection", () => {
   it("shows an empty state when no active requester exists", async () => {
     vi.spyOn(api, "loadReferenceData").mockResolvedValue({ ...referenceData, requesters: [] });
 
-    render(<App />);
+    renderApp();
 
     expect(await screen.findByText("No active Development Requesters are available.")).toBeInTheDocument();
   });
@@ -55,7 +60,7 @@ describe("Development Requester selection", () => {
       .mockRejectedValueOnce(new Error("offline"))
       .mockResolvedValueOnce(referenceData);
     const user = userEvent.setup();
-    render(<App />);
+    renderApp();
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Unable to load requester and reference data.");
     await user.click(screen.getByRole("button", { name: "Retry" }));

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -18,7 +18,7 @@ inactive requester.
 | API-04 | API | AC-07, AC-10 | Owned detail succeeds; cross-requester detail returns 404 | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
 | API-05 | API | AC-11, AC-12, AC-13 | Upload, size/type/count limits, removal, and blocked download | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | UI-01 | UI | AC-01, AC-02 | Selector loading, empty, failure, selection, and Change Requester states | `client/tests/lab-02/RequesterSelection.test.tsx` | Pass |
-| UI-02 | UI | AC-03–AC-05 | Create form validation, busy, success, and retained failure values | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
+| UI-02 | UI | AC-03–AC-05 | Create form validation, busy, success, and retained failure values | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
 | UI-03 | UI | AC-06, AC-08, AC-09 | My Tickets loading, filters, pagination, empty/no-results/error states | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
 | UI-04 | UI | AC-10–AC-13 | Read-only detail and attachment action states | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
 | STYLE-01 | UI style | AC-14 | Labels, asterisks, invalid classes, busy controls, and read-only treatment | `client/tests/lab-02/ui-style.test.tsx` | Planned |
@@ -82,6 +82,13 @@ Ticket-creation API verification completed on `feature/8-ticket-create-api`:
 - `cd server && npm test` — 17 tests passed.
 - `cd server && npm run build` — passed.
 - `cd client && npm test` — 5 tests passed.
+- `cd client && npm run build` — passed.
+
+Create Ticket UI verification completed on `feature/9-create-ticket-ui`:
+
+- `cd server && npm test` — 17 tests passed.
+- `cd server && npm run build` — passed.
+- `cd client && npm test` — 9 tests passed.
 - `cd client && npm run build` — passed.
 
 ## 7. Known Limitations or Deferred Tests


### PR DESCRIPTION
Closes #15

## Summary
- add React Router application shell with requester context and Create Ticket route
- implement client validation, busy, success, and safe API-error states
- add Create Ticket UI coverage and update Lab 2 test traceability

## Verification
- npm test --prefix server (17 passing)
- npm run build --prefix server
- npm test --prefix client (9 passing)
- npm run build --prefix client