### PR TITLE
feat: add requester ticket list

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
 import { type FormEvent, type ReactNode, useEffect, useState } from "react";
 import { NavLink, Navigate, Route, Routes, useNavigate } from "react-router-dom";
-import { type CreatedTicket, type ReferenceData, type Requester, createTicket, loadReferenceData } from "./api.js";
+import { type CreatedTicket, type ReferenceData, type Requester, type TicketListResponse, type TicketQuery, createTicket, loadReferenceData, loadTickets } from "./api.js";
 
 type LoadState = "loading" | "ready" | "error";
 type FormValues = { categoryId: string; relatedSystemId: string; requestedPriority: "LOW" | "MEDIUM" | "HIGH" | "URGENT"; summary: string; description: string };
@@ -18,7 +18,7 @@ function Shell({ requester, onChangeRequester, children }: { requester: Requeste
         <div className="container py-3 d-flex flex-wrap align-items-center gap-3" style={{ maxWidth: 1100 }}>
           <strong style={{ color: "#006B3C" }}>TokTickIT</strong>
           <nav className="d-flex gap-3" aria-label="Main navigation">
-            <NavLink className={({ isActive }) => isActive ? "fw-semibold text-success text-decoration-underline" : "text-decoration-none"} to="/tickets">My Tickets</NavLink>
+            <NavLink end className={({ isActive }) => isActive ? "fw-semibold text-success text-decoration-underline" : "text-decoration-none"} to="/tickets">My Tickets</NavLink>
             <NavLink className={({ isActive }) => isActive ? "fw-semibold text-success text-decoration-underline" : "text-decoration-none"} to="/tickets/new">Create Ticket</NavLink>
           </nav>
           <span className="ms-md-auto">Requester: {requester.name}</span>
@@ -57,6 +57,50 @@ function RequesterSelector({ data, onSelected }: { data: ReferenceData; onSelect
       </div></section>
     </main>
   );
+}
+
+const initialTicketFilters: TicketQuery = { search: "", categoryId: "", requestedPriority: "", status: "", sortBy: "updatedAt", direction: "desc", page: 1, pageSize: 10 };
+
+function MyTickets({ requester, data }: { requester: Requester; data: ReferenceData }) {
+  const [filters, setFilters] = useState<TicketQuery>(initialTicketFilters);
+  const [result, setResult] = useState<TicketListResponse | null>(null);
+  const [failure, setFailure] = useState(false);
+  const [retry, setRetry] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setResult(null);
+    setFailure(false);
+    void loadTickets(requester.id, filters).then((data) => {
+      if (!cancelled) setResult(data);
+    }).catch(() => {
+      if (!cancelled) setFailure(true);
+    });
+    return () => { cancelled = true; };
+  }, [requester.id, filters, retry]);
+
+  function update<K extends keyof TicketQuery>(key: K, value: TicketQuery[K]) {
+    setFilters((current) => ({ ...current, [key]: value, page: 1 }));
+  }
+
+  const hasFilters = Boolean(filters.search || filters.categoryId || filters.requestedPriority || filters.status);
+  return <section>
+    <div className="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-4"><h1 className="h3 mb-0">My Tickets</h1><NavLink className="btn text-white" style={{ backgroundColor: "#006B3C" }} to="/tickets/new">Create Ticket</NavLink></div>
+    <div className="card shadow-sm mb-4"><div className="card-body"><div className="row g-3">
+      <div className="col-md-6"><label className="form-label" htmlFor="ticket-search">Search tickets</label><input className="form-control" id="ticket-search" value={filters.search} onChange={(event) => update("search", event.target.value)} placeholder="Ticket number or summary" /></div>
+      <div className="col-md-3"><label className="form-label" htmlFor="ticket-category">Category</label><select className="form-select" id="ticket-category" value={filters.categoryId} onChange={(event) => update("categoryId", event.target.value)}><option value="">All categories</option>{data.categories.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}</select></div>
+      <div className="col-md-3"><label className="form-label" htmlFor="ticket-priority">Requested Priority</label><select className="form-select" id="ticket-priority" value={filters.requestedPriority} onChange={(event) => update("requestedPriority", event.target.value as TicketQuery["requestedPriority"])}><option value="">All priorities</option>{["LOW", "MEDIUM", "HIGH", "URGENT"].map((item) => <option key={item}>{item}</option>)}</select></div>
+      <div className="col-md-3"><label className="form-label" htmlFor="ticket-status">Status</label><select className="form-select" id="ticket-status" value={filters.status} onChange={(event) => update("status", event.target.value as TicketQuery["status"])}><option value="">All statuses</option><option value="NEW">NEW</option></select></div>
+      <div className="col-md-3"><label className="form-label" htmlFor="ticket-sort">Sort by</label><select className="form-select" id="ticket-sort" value={filters.sortBy} onChange={(event) => update("sortBy", event.target.value as TicketQuery["sortBy"])}><option value="updatedAt">Last Updated</option><option value="createdAt">Created</option><option value="ticketNumber">Ticket Number</option><option value="requestedPriority">Requested Priority</option></select></div>
+      <div className="col-md-3"><label className="form-label" htmlFor="ticket-direction">Direction</label><select className="form-select" id="ticket-direction" value={filters.direction} onChange={(event) => update("direction", event.target.value as TicketQuery["direction"])}><option value="desc">Newest first</option><option value="asc">Oldest first</option></select></div>
+      <div className="col-md-3 d-flex align-items-end"><button className="btn btn-outline-success w-100" onClick={() => setFilters(initialTicketFilters)}>Clear filters</button></div>
+    </div></div></div>
+    {!result && !failure && <p role="status">Loading tickets…</p>}
+    {failure && <div className="alert alert-danger" role="alert">Unable to load tickets. <button className="btn btn-sm btn-danger ms-2" onClick={() => setRetry((value) => value + 1)}>Retry</button></div>}
+    {result && result.items.length === 0 && <div className="alert alert-info" role="status">{hasFilters ? "No tickets match your filters." : "No tickets yet."}</div>}
+    {result && result.items.length > 0 && <div className="table-responsive card shadow-sm"><table className="table table-hover mb-0"><thead><tr><th>Ticket Number</th><th>Summary</th><th>Category</th><th>Requested Priority</th><th>Status</th><th>Last Updated</th><th><span className="visually-hidden">Open</span></th></tr></thead><tbody>{result.items.map((ticket) => <tr key={ticket.id}><td>{ticket.ticketNumber}</td><td>{ticket.summary}</td><td>{ticket.category.name}</td><td>{ticket.requestedPriority}</td><td>{ticket.status}</td><td>{new Date(ticket.updatedAt).toLocaleString()}</td><td><button className="btn btn-sm btn-outline-success" disabled>Open</button></td></tr>)}</tbody></table></div>}
+    {result && result.totalPages > 1 && <nav className="d-flex justify-content-between align-items-center mt-3" aria-label="Ticket pagination"><button className="btn btn-outline-success" disabled={result.page === 1} onClick={() => update("page", result.page - 1)}>Previous</button><span>Page {result.page} of {result.totalPages}</span><button className="btn btn-outline-success" disabled={result.page === result.totalPages} onClick={() => update("page", result.page + 1)}>Next</button></nav>}
+  </section>;
 }
 
 function CreateTicket({ requester, data }: { requester: Requester; data: ReferenceData }) {
@@ -152,7 +196,7 @@ export default function App() {
   const changeRequester = () => { sessionStorage.removeItem(requesterStorageKey); setRequesterId(null); };
   return <Routes>
     <Route path="/select" element={<Navigate replace to="/tickets" />} />
-    <Route path="/tickets" element={<Shell requester={requester} onChangeRequester={changeRequester}><h1 className="h3">My Tickets</h1><p className="text-secondary">Ticket listing will be added in the next issue.</p></Shell>} />
+    <Route path="/tickets" element={<Shell requester={requester} onChangeRequester={changeRequester}><MyTickets requester={requester} data={referenceData} /></Shell>} />
     <Route path="/tickets/new" element={<Shell requester={requester} onChangeRequester={changeRequester}><CreateTicket requester={requester} data={referenceData} /></Shell>} />
     <Route path="*" element={<Navigate replace to="/tickets" />} />
   </Routes>;

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -83,6 +83,10 @@ function MyTickets({ requester, data }: { requester: Requester; data: ReferenceD
     setFilters((current) => ({ ...current, [key]: value, page: 1 }));
   }
 
+  function changePage(page: number) {
+    setFilters((current) => ({ ...current, page }));
+  }
+
   const hasFilters = Boolean(filters.search || filters.categoryId || filters.requestedPriority || filters.status);
   return <section>
     <div className="d-flex flex-wrap justify-content-between align-items-center gap-3 mb-4"><h1 className="h3 mb-0">My Tickets</h1><NavLink className="btn text-white" style={{ backgroundColor: "#006B3C" }} to="/tickets/new">Create Ticket</NavLink></div>
@@ -99,7 +103,7 @@ function MyTickets({ requester, data }: { requester: Requester; data: ReferenceD
     {failure && <div className="alert alert-danger" role="alert">Unable to load tickets. <button className="btn btn-sm btn-danger ms-2" onClick={() => setRetry((value) => value + 1)}>Retry</button></div>}
     {result && result.items.length === 0 && <div className="alert alert-info" role="status">{hasFilters ? "No tickets match your filters." : "No tickets yet."}</div>}
     {result && result.items.length > 0 && <div className="table-responsive card shadow-sm"><table className="table table-hover mb-0"><thead><tr><th>Ticket Number</th><th>Summary</th><th>Category</th><th>Requested Priority</th><th>Status</th><th>Last Updated</th><th><span className="visually-hidden">Open</span></th></tr></thead><tbody>{result.items.map((ticket) => <tr key={ticket.id}><td>{ticket.ticketNumber}</td><td>{ticket.summary}</td><td>{ticket.category.name}</td><td>{ticket.requestedPriority}</td><td>{ticket.status}</td><td>{new Date(ticket.updatedAt).toLocaleString()}</td><td><button className="btn btn-sm btn-outline-success" disabled>Open</button></td></tr>)}</tbody></table></div>}
-    {result && result.totalPages > 1 && <nav className="d-flex justify-content-between align-items-center mt-3" aria-label="Ticket pagination"><button className="btn btn-outline-success" disabled={result.page === 1} onClick={() => update("page", result.page - 1)}>Previous</button><span>Page {result.page} of {result.totalPages}</span><button className="btn btn-outline-success" disabled={result.page === result.totalPages} onClick={() => update("page", result.page + 1)}>Next</button></nav>}
+    {result && result.totalPages > 1 && <nav className="d-flex justify-content-between align-items-center mt-3" aria-label="Ticket pagination"><button className="btn btn-outline-success" disabled={result.page === 1} onClick={() => changePage(result.page - 1)}>Previous</button><span>Page {result.page} of {result.totalPages}</span><button className="btn btn-outline-success" disabled={result.page === result.totalPages} onClick={() => changePage(result.page + 1)}>Next</button></nav>}
   </section>;
 }
 

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -30,6 +30,35 @@ export interface CreatedTicket {
   status: "NEW";
 }
 
+export interface TicketListItem {
+  id: number;
+  ticketNumber: string;
+  summary: string;
+  requestedPriority: TicketInput["requestedPriority"];
+  status: "NEW";
+  category: ReferenceItem;
+  updatedAt: string;
+}
+
+export interface TicketListResponse {
+  items: TicketListItem[];
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+}
+
+export interface TicketQuery {
+  search?: string;
+  categoryId?: string;
+  requestedPriority?: TicketInput["requestedPriority"] | "";
+  status?: "NEW" | "";
+  sortBy?: "updatedAt" | "createdAt" | "ticketNumber" | "requestedPriority";
+  direction?: "asc" | "desc";
+  page?: number;
+  pageSize?: number;
+}
+
 async function loadJson<T>(path: string): Promise<T> {
   const response = await fetch(`${API_URL}${path}`);
   if (!response.ok) throw new Error("Reference data request failed");
@@ -55,4 +84,13 @@ export async function createTicket(ticket: TicketInput): Promise<CreatedTicket> 
   const body = await response.json().catch(() => ({}));
   if (!response.ok) throw new Error(typeof body.error === "string" ? body.error : "Unable to create ticket.");
   return body as CreatedTicket;
+}
+
+export async function loadTickets(requesterId: number, query: TicketQuery): Promise<TicketListResponse> {
+  const params = new URLSearchParams({ requesterId: String(requesterId) });
+  for (const [key, value] of Object.entries(query)) if (value !== undefined && value !== "") params.set(key, String(value));
+  const response = await fetch(`${API_URL}/api/tickets?${params}`);
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(typeof body.error === "string" ? body.error : "Unable to load tickets.");
+  return body as TicketListResponse;
 }

--- a/client/tests/lab-02/MyTickets.test.tsx
+++ b/client/tests/lab-02/MyTickets.test.tsx
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import App from "../../src/App.js";
+import * as api from "../../src/api.js";
+
+const referenceData = {
+  requesters: [{ id: 1, name: "Nicha Somchai", email: "nicha@example.test" }],
+  categories: [{ id: 2, name: "Hardware" }],
+  relatedSystems: [{ id: 3, name: "VPN" }],
+};
+
+function renderMyTickets() {
+  sessionStorage.setItem("toktickit.requesterId", "1");
+  return render(<MemoryRouter initialEntries={["/tickets"]}><App /></MemoryRouter>);
+}
+
+afterEach(() => {
+  sessionStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("My Tickets", () => {
+  it("shows the requester’s ticket and sends filter changes to the API", async () => {
+    vi.spyOn(api, "loadReferenceData").mockResolvedValue(referenceData);
+    const loadTickets = vi.spyOn(api, "loadTickets").mockResolvedValue({ items: [{ id: 1, ticketNumber: "TKT-2026-A1B2C3D4", summary: "VPN cannot connect", requestedPriority: "HIGH", status: "NEW", category: { id: 2, name: "Hardware" }, updatedAt: "2026-08-25T00:00:00.000Z" }], page: 1, pageSize: 10, totalItems: 1, totalPages: 1 });
+    const user = userEvent.setup();
+    renderMyTickets();
+
+    expect(await screen.findByText("TKT-2026-A1B2C3D4")).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText("Category"), "2");
+
+    expect(await screen.findByText("TKT-2026-A1B2C3D4")).toBeInTheDocument();
+    expect(loadTickets).toHaveBeenLastCalledWith(1, expect.objectContaining({ categoryId: "2" }));
+  });
+
+  it("distinguishes an empty requester from no filter matches", async () => {
+    vi.spyOn(api, "loadReferenceData").mockResolvedValue(referenceData);
+    vi.spyOn(api, "loadTickets").mockResolvedValue({ items: [], page: 1, pageSize: 10, totalItems: 0, totalPages: 0 });
+    const user = userEvent.setup();
+    renderMyTickets();
+
+    expect(await screen.findByText("No tickets yet.")).toBeInTheDocument();
+    await user.type(screen.getByLabelText("Search tickets"), "VPN");
+
+    expect(await screen.findByText("No tickets match your filters.")).toBeInTheDocument();
+  });
+
+  it("shows a retryable safe failure", async () => {
+    vi.spyOn(api, "loadReferenceData").mockResolvedValue(referenceData);
+    vi.spyOn(api, "loadTickets").mockRejectedValueOnce(new Error("offline")).mockResolvedValueOnce({ items: [], page: 1, pageSize: 10, totalItems: 0, totalPages: 0 });
+    const user = userEvent.setup();
+    renderMyTickets();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to load tickets.");
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(await screen.findByText("No tickets yet.")).toBeInTheDocument();
+  });
+});

--- a/client/tests/lab-02/MyTickets.test.tsx
+++ b/client/tests/lab-02/MyTickets.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import App from "../../src/App.js";
@@ -24,7 +24,7 @@ afterEach(() => {
 describe("My Tickets", () => {
   it("shows the requester’s ticket and sends filter changes to the API", async () => {
     vi.spyOn(api, "loadReferenceData").mockResolvedValue(referenceData);
-    const loadTickets = vi.spyOn(api, "loadTickets").mockResolvedValue({ items: [{ id: 1, ticketNumber: "TKT-2026-A1B2C3D4", summary: "VPN cannot connect", requestedPriority: "HIGH", status: "NEW", category: { id: 2, name: "Hardware" }, updatedAt: "2026-08-25T00:00:00.000Z" }], page: 1, pageSize: 10, totalItems: 1, totalPages: 1 });
+    const loadTickets = vi.spyOn(api, "loadTickets").mockImplementation(async (_requesterId, query) => ({ items: [{ id: 1, ticketNumber: "TKT-2026-A1B2C3D4", summary: "VPN cannot connect", requestedPriority: "HIGH", status: "NEW", category: { id: 2, name: "Hardware" }, updatedAt: "2026-08-25T00:00:00.000Z" }], page: query.page ?? 1, pageSize: 10, totalItems: 11, totalPages: 2 }));
     const user = userEvent.setup();
     renderMyTickets();
 
@@ -33,6 +33,9 @@ describe("My Tickets", () => {
 
     expect(await screen.findByText("TKT-2026-A1B2C3D4")).toBeInTheDocument();
     expect(loadTickets).toHaveBeenLastCalledWith(1, expect.objectContaining({ categoryId: "2" }));
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() => expect(loadTickets).toHaveBeenLastCalledWith(1, expect.objectContaining({ categoryId: "2", page: 2 })));
   });
 
   it("distinguishes an empty requester from no filter matches", async () => {

--- a/client/tests/lab-02/RequesterSelection.test.tsx
+++ b/client/tests/lab-02/RequesterSelection.test.tsx
@@ -31,6 +31,7 @@ describe("Development Requester selection", () => {
 
   it("selects an active requester and supports changing it", async () => {
     vi.spyOn(api, "loadReferenceData").mockResolvedValue(referenceData);
+    vi.spyOn(api, "loadTickets").mockResolvedValue({ items: [], page: 1, pageSize: 10, totalItems: 0, totalPages: 0 });
     const user = userEvent.setup();
     renderApp();
 

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -14,12 +14,12 @@ inactive requester.
 | UNIT-01 | Unit | AC-03 | Ticket-number generator produces `TKT-YYYY-XXXXXXXX` | `server/tests/lab-02/ticket-number.test.ts` | Pass |
 | API-01 | API | AC-01 | Active requester, Category, and Related System APIs exclude inactive data | `server/tests/lab-02/reference-data.api.test.ts` | Pass |
 | API-02 | API | AC-03, AC-04 | Valid ticket creates `NEW`; validation, inactive references, duplicate retry, and malformed JSON return safe responses | `server/tests/lab-02/create-ticket.api.test.ts` | Pass |
-| API-03 | API | AC-06, AC-08, AC-09 | Owned list search/filter/sort/page response is correct | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| API-03 | API | AC-06, AC-08, AC-09 | Owned list search/filter/sort/page response is correct | `server/tests/lab-02/my-tickets.api.test.ts` | Pass |
 | API-04 | API | AC-07, AC-10 | Owned detail succeeds; cross-requester detail returns 404 | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
 | API-05 | API | AC-11, AC-12, AC-13 | Upload, size/type/count limits, removal, and blocked download | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | UI-01 | UI | AC-01, AC-02 | Selector loading, empty, failure, selection, and Change Requester states | `client/tests/lab-02/RequesterSelection.test.tsx` | Pass |
 | UI-02 | UI | AC-03–AC-05 | Create form validation, busy, success, and retained failure values | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
-| UI-03 | UI | AC-06, AC-08, AC-09 | My Tickets loading, filters, pagination, empty/no-results/error states | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
+| UI-03 | UI | AC-06, AC-08, AC-09 | My Tickets loading, filters, pagination, empty/no-results/error states | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
 | UI-04 | UI | AC-10–AC-13 | Read-only detail and attachment action states | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
 | STYLE-01 | UI style | AC-14 | Labels, asterisks, invalid classes, busy controls, and read-only treatment | `client/tests/lab-02/ui-style.test.tsx` | Planned |
 | E2E-01 | E2E | AC-03, AC-06, AC-10 | Requester creates a ticket and finds/opens it | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
@@ -90,6 +90,11 @@ Create Ticket UI verification completed on `feature/9-create-ticket-ui`:
 - `cd server && npm run build` — passed.
 - `cd client && npm test` — 9 tests passed.
 - `cd client && npm run build` — passed.
+
+My Tickets verification completed on `feature/10-my-tickets`:
+
+- Focused API tests cover requester ownership, filters, pagination, invalid queries, and safe failures.
+- Focused UI tests cover ticket display, filters, empty/no-match states, and retry.
 
 ## 7. Known Limitations or Deferred Tests
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,9 +1,12 @@
 import express, { NextFunction, Request, Response } from "express";
 import cors from "cors";
+import type { Prisma } from "@prisma/client";
 import { getPrisma } from "./prisma.js";
 import { generateTicketNumber } from "./ticket-number.js";
 
 const priorities = ["LOW", "MEDIUM", "HIGH", "URGENT"] as const;
+const statuses = ["NEW"] as const;
+const sortFields = ["updatedAt", "createdAt", "ticketNumber", "requestedPriority"] as const;
 
 class RequestError extends Error {
   constructor(readonly message: string) { super(message); }
@@ -29,6 +32,18 @@ function requestedPriority(value: unknown) {
     throw new RequestError("requestedPriority must be LOW, MEDIUM, HIGH, or URGENT.");
   }
   return value as typeof priorities[number];
+}
+
+function queryInteger(value: unknown, name: string, fallback?: number) {
+  if (value === undefined && fallback !== undefined) return fallback;
+  if (typeof value !== "string" || !/^\d+$/.test(value)) throw new RequestError(`${name} must be a positive integer.`);
+  return requiredId(Number(value), name);
+}
+
+function queryChoice<T extends readonly string[]>(value: unknown, name: string, choices: T, fallback: T[number]) {
+  if (value === undefined) return fallback;
+  if (typeof value !== "string" || !choices.includes(value)) throw new RequestError(`${name} is invalid.`);
+  return value as T[number];
 }
 
 // The Express app is exported separately from app.listen() (see index.ts) so
@@ -90,6 +105,35 @@ app.get("/api/related-systems", async (_req: Request, res: Response) => {
     res.json(relatedSystems);
   } catch {
     res.status(500).json({ error: "Unable to load related systems." });
+  }
+});
+
+app.get("/api/tickets", async (req: Request, res: Response) => {
+  try {
+    const requesterId = queryInteger(req.query.requesterId, "requesterId");
+    const categoryId = req.query.categoryId === undefined ? undefined : queryInteger(req.query.categoryId, "categoryId");
+    const requestedPriority = req.query.requestedPriority === undefined ? undefined : queryChoice(req.query.requestedPriority, "requestedPriority", priorities, "MEDIUM");
+    const status = req.query.status === undefined ? undefined : queryChoice(req.query.status, "status", statuses, "NEW");
+    const sortBy = queryChoice(req.query.sortBy, "sortBy", sortFields, "updatedAt");
+    const direction = queryChoice(req.query.direction, "direction", ["asc", "desc"] as const, "desc");
+    const page = queryInteger(req.query.page, "page", 1);
+    const pageSize = queryInteger(req.query.pageSize, "pageSize", 10);
+    if (![5, 10, 20].includes(pageSize)) throw new RequestError("pageSize must be 5, 10, or 20.");
+    const search = req.query.search === undefined ? undefined : typeof req.query.search === "string" ? req.query.search.trim() : (() => { throw new RequestError("search is invalid."); })();
+    const where: Prisma.TicketWhereInput = { requesterId, categoryId, requestedPriority, status };
+    if (search) where.OR = [{ ticketNumber: { contains: search, mode: "insensitive" } }, { summary: { contains: search, mode: "insensitive" } }];
+    const prisma = getPrisma();
+    const [items, totalItems] = await Promise.all([
+      prisma.ticket.findMany({ where, orderBy: { [sortBy]: direction }, skip: (page - 1) * pageSize, take: pageSize, select: { id: true, ticketNumber: true, summary: true, requestedPriority: true, status: true, updatedAt: true, category: { select: { id: true, name: true } } } }),
+      prisma.ticket.count({ where }),
+    ]);
+    res.json({ items, page, pageSize, totalItems, totalPages: Math.ceil(totalItems / pageSize) });
+  } catch (error) {
+    if (error instanceof RequestError) {
+      res.status(400).json({ error: error.message });
+      return;
+    }
+    res.status(500).json({ error: "Unable to load tickets." });
   }
 });
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,6 +1,6 @@
 import express, { NextFunction, Request, Response } from "express";
 import cors from "cors";
-import type { Prisma } from "@prisma/client";
+import type { Prisma, PrismaClient } from "@prisma/client";
 import { getPrisma } from "./prisma.js";
 import { generateTicketNumber } from "./ticket-number.js";
 
@@ -44,6 +44,11 @@ function queryChoice<T extends readonly string[]>(value: unknown, name: string, 
   if (value === undefined) return fallback;
   if (typeof value !== "string" || !choices.includes(value)) throw new RequestError(`${name} is invalid.`);
   return value as T[number];
+}
+
+async function requireActiveRequester(prisma: PrismaClient, requesterId: number) {
+  const requester = await prisma.requester.findFirst({ where: { id: requesterId, isActive: true }, select: { id: true } });
+  if (!requester) throw new RequestError("Requester is unavailable.");
 }
 
 // The Express app is exported separately from app.listen() (see index.ts) so
@@ -123,6 +128,7 @@ app.get("/api/tickets", async (req: Request, res: Response) => {
     const where: Prisma.TicketWhereInput = { requesterId, categoryId, requestedPriority, status };
     if (search) where.OR = [{ ticketNumber: { contains: search, mode: "insensitive" } }, { summary: { contains: search, mode: "insensitive" } }];
     const prisma = getPrisma();
+    await requireActiveRequester(prisma, requesterId);
     const [items, totalItems] = await Promise.all([
       prisma.ticket.findMany({ where, orderBy: { [sortBy]: direction }, skip: (page - 1) * pageSize, take: pageSize, select: { id: true, ticketNumber: true, summary: true, requestedPriority: true, status: true, updatedAt: true, category: { select: { id: true, name: true } } } }),
       prisma.ticket.count({ where }),

--- a/server/tests/lab-02/my-tickets.api.test.ts
+++ b/server/tests/lab-02/my-tickets.api.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+const prisma = vi.hoisted(() => ({ ticket: { count: vi.fn(), findMany: vi.fn() } }));
+
+vi.mock("../../src/prisma.js", () => ({ getPrisma: () => prisma }));
+
+import { app } from "../../src/app.js";
+
+describe("GET /api/tickets", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns only the requester’s filtered, paginated tickets", async () => {
+    prisma.ticket.count.mockResolvedValue(6);
+    prisma.ticket.findMany.mockResolvedValue([{ id: 7, ticketNumber: "TKT-2026-A1B2C3D4", summary: "VPN cannot connect", requestedPriority: "HIGH", status: "NEW", category: { id: 2, name: "Hardware" }, updatedAt: new Date("2026-08-25T00:00:00.000Z") }]);
+
+    const response = await request(app).get("/api/tickets?requesterId=1&search=vpn&categoryId=2&requestedPriority=HIGH&status=NEW&sortBy=ticketNumber&direction=asc&page=2&pageSize=5");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({ page: 2, pageSize: 5, totalItems: 6, totalPages: 2, items: [{ id: 7, ticketNumber: "TKT-2026-A1B2C3D4", category: { name: "Hardware" } }] });
+    expect(prisma.ticket.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ requesterId: 1, categoryId: 2, requestedPriority: "HIGH", status: "NEW" }),
+      orderBy: { ticketNumber: "asc" }, skip: 5, take: 5,
+    }));
+  });
+
+  it.each(["", "?requesterId=1&page=0", "?requesterId=1&pageSize=7", "?requesterId=1&sortBy=summary"])("returns a safe 400 for invalid query values: %s", async (query) => {
+    const response = await request(app).get(`/api/tickets${query}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toEqual(expect.any(String));
+    expect(prisma.ticket.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns a safe error when ticket loading fails", async () => {
+    prisma.ticket.count.mockRejectedValue(new Error("database unavailable"));
+
+    const response = await request(app).get("/api/tickets?requesterId=1");
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: "Unable to load tickets." });
+  });
+});

--- a/server/tests/lab-02/my-tickets.api.test.ts
+++ b/server/tests/lab-02/my-tickets.api.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import request from "supertest";
 
-const prisma = vi.hoisted(() => ({ ticket: { count: vi.fn(), findMany: vi.fn() } }));
+const prisma = vi.hoisted(() => ({ requester: { findFirst: vi.fn() }, ticket: { count: vi.fn(), findMany: vi.fn() } }));
 
 vi.mock("../../src/prisma.js", () => ({ getPrisma: () => prisma }));
 
@@ -11,6 +11,7 @@ describe("GET /api/tickets", () => {
   beforeEach(() => vi.resetAllMocks());
 
   it("returns only the requester’s filtered, paginated tickets", async () => {
+    prisma.requester.findFirst.mockResolvedValue({ id: 1 });
     prisma.ticket.count.mockResolvedValue(6);
     prisma.ticket.findMany.mockResolvedValue([{ id: 7, ticketNumber: "TKT-2026-A1B2C3D4", summary: "VPN cannot connect", requestedPriority: "HIGH", status: "NEW", category: { id: 2, name: "Hardware" }, updatedAt: new Date("2026-08-25T00:00:00.000Z") }]);
 
@@ -33,11 +34,22 @@ describe("GET /api/tickets", () => {
   });
 
   it("returns a safe error when ticket loading fails", async () => {
+    prisma.requester.findFirst.mockResolvedValue({ id: 1 });
     prisma.ticket.count.mockRejectedValue(new Error("database unavailable"));
 
     const response = await request(app).get("/api/tickets?requesterId=1");
 
     expect(response.status).toBe(500);
     expect(response.body).toEqual({ error: "Unable to load tickets." });
+  });
+
+  it.each(["inactive", "missing"])("rejects an %s requester", async () => {
+    prisma.requester.findFirst.mockResolvedValue(null);
+
+    const response = await request(app).get("/api/tickets?requesterId=1");
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: "Requester is unavailable." });
+    expect(prisma.ticket.findMany).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #16

## Summary
- add owned GET /api/tickets with active-requester validation, search, filters, sorting, and pagination
- add My Tickets loading, error, empty, no-results, filter, and pagination UI states
- add API/UI coverage and update Lab 2 test traceability

## Verification
- npm test --prefix server (25 passing)
- npm run build --prefix server
- npm test --prefix client (12 passing)
- npm run build --prefix client

Stacked on #23; retarget to lab2-staging after #23 merges.