### PR TITLE
feat: add ticket detail and attachments

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
 import { type FormEvent, type ReactNode, useEffect, useState } from "react";
-import { NavLink, Navigate, Route, Routes, useNavigate } from "react-router-dom";
-import { type CreatedTicket, type ReferenceData, type Requester, type TicketListResponse, type TicketQuery, createTicket, loadReferenceData, loadTickets } from "./api.js";
+import { NavLink, Navigate, Route, Routes, useNavigate, useParams } from "react-router-dom";
+import { type CreatedTicket, type ReferenceData, type Requester, type TicketDetail, type TicketListResponse, type TicketQuery, attachmentDownloadUrl, createTicket, loadReferenceData, loadTicket, loadTickets, removeAttachment, uploadAttachment } from "./api.js";
 
 type LoadState = "loading" | "ready" | "error";
 type FormValues = { categoryId: string; relatedSystemId: string; requestedPriority: "LOW" | "MEDIUM" | "HIGH" | "URGENT"; summary: string; description: string };
@@ -102,8 +102,76 @@ function MyTickets({ requester, data }: { requester: Requester; data: ReferenceD
     {!result && !failure && <p role="status">Loading tickets…</p>}
     {failure && <div className="alert alert-danger" role="alert">Unable to load tickets. <button className="btn btn-sm btn-danger ms-2" onClick={() => setRetry((value) => value + 1)}>Retry</button></div>}
     {result && result.items.length === 0 && <div className="alert alert-info" role="status">{hasFilters ? "No tickets match your filters." : "No tickets yet."}</div>}
-    {result && result.items.length > 0 && <div className="table-responsive card shadow-sm"><table className="table table-hover mb-0"><thead><tr><th>Ticket Number</th><th>Summary</th><th>Category</th><th>Requested Priority</th><th>Status</th><th>Last Updated</th><th><span className="visually-hidden">Open</span></th></tr></thead><tbody>{result.items.map((ticket) => <tr key={ticket.id}><td>{ticket.ticketNumber}</td><td>{ticket.summary}</td><td>{ticket.category.name}</td><td>{ticket.requestedPriority}</td><td>{ticket.status}</td><td>{new Date(ticket.updatedAt).toLocaleString()}</td><td><button className="btn btn-sm btn-outline-success" disabled>Open</button></td></tr>)}</tbody></table></div>}
+    {result && result.items.length > 0 && <div className="table-responsive card shadow-sm"><table className="table table-hover mb-0"><thead><tr><th>Ticket Number</th><th>Summary</th><th>Category</th><th>Requested Priority</th><th>Status</th><th>Last Updated</th><th><span className="visually-hidden">Open</span></th></tr></thead><tbody>{result.items.map((ticket) => <tr key={ticket.id}><td>{ticket.ticketNumber}</td><td>{ticket.summary}</td><td>{ticket.category.name}</td><td>{ticket.requestedPriority}</td><td>{ticket.status}</td><td>{new Date(ticket.updatedAt).toLocaleString()}</td><td><NavLink className="btn btn-sm btn-outline-success" to={`/tickets/${ticket.id}`}>Open</NavLink></td></tr>)}</tbody></table></div>}
     {result && result.totalPages > 1 && <nav className="d-flex justify-content-between align-items-center mt-3" aria-label="Ticket pagination"><button className="btn btn-outline-success" disabled={result.page === 1} onClick={() => changePage(result.page - 1)}>Previous</button><span>Page {result.page} of {result.totalPages}</span><button className="btn btn-outline-success" disabled={result.page === result.totalPages} onClick={() => changePage(result.page + 1)}>Next</button></nav>}
+  </section>;
+}
+
+function TicketDetailPage({ requester, ticketId }: { requester: Requester; ticketId: number }) {
+  const [ticket, setTicket] = useState<TicketDetail | null>(null);
+  const [failure, setFailure] = useState(false);
+  const [retry, setRetry] = useState(0);
+  const [file, setFile] = useState<File | null>(null);
+  const [uploadError, setUploadError] = useState("");
+  const [uploading, setUploading] = useState(false);
+  const [removingId, setRemovingId] = useState<number | null>(null);
+  const [removalReason, setRemovalReason] = useState("");
+  const [removing, setRemoving] = useState(false);
+  const [removeError, setRemoveError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    setTicket(null);
+    setFailure(false);
+    void loadTicket(ticketId, requester.id).then((data) => { if (!cancelled) setTicket(data); }).catch(() => { if (!cancelled) setFailure(true); });
+    return () => { cancelled = true; };
+  }, [requester.id, retry, ticketId]);
+
+  async function upload() {
+    if (!file || !ticket) return;
+    if (!["image/jpeg", "image/png", "image/webp", "application/pdf"].includes(file.type) || file.size > 5 * 1024 * 1024) {
+      setUploadError("Choose a JPG, PNG, WEBP, or PDF file no larger than 5 MB.");
+      return;
+    }
+    setUploading(true);
+    setUploadError("");
+    try {
+      const attachment = await uploadAttachment(ticket.id, requester.id, file);
+      setTicket({ ...ticket, attachments: [attachment, ...ticket.attachments] });
+      setFile(null);
+    } catch (error) {
+      setUploadError(error instanceof Error ? error.message : "Unable to upload attachment.");
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function remove() {
+    if (!removingId || !ticket) return;
+    if (removalReason.trim().length < 1 || removalReason.trim().length > 500) return;
+    setRemoving(true);
+    setRemoveError("");
+    try {
+      const updated = await removeAttachment(removingId, requester.id, removalReason);
+      setTicket({ ...ticket, attachments: ticket.attachments.map((item) => item.id === updated.id ? updated : item) });
+      setRemovingId(null);
+      setRemovalReason("");
+    } catch (error) {
+      setRemoveError(error instanceof Error ? error.message : "Unable to remove attachment.");
+    } finally {
+      setRemoving(false);
+    }
+  }
+
+  if (!ticket && !failure) return <p role="status">Loading ticket…</p>;
+  if (failure) return <div className="alert alert-danger" role="alert">Unable to load ticket. <button className="btn btn-sm btn-danger ms-2" onClick={() => setRetry((value) => value + 1)}>Retry</button></div>;
+  if (!ticket) return null;
+  return <section>
+    <NavLink className="btn btn-sm btn-outline-success mb-3" to="/tickets">Back to My Tickets</NavLink>
+    <div className="card shadow-sm mb-4"><div className="card-body"><h1 className="h3">{ticket.ticketNumber}</h1><dl className="row mb-0"><dt className="col-sm-3">Summary</dt><dd className="col-sm-9">{ticket.summary}</dd><dt className="col-sm-3">Description</dt><dd className="col-sm-9" style={{ whiteSpace: "pre-wrap" }}>{ticket.description}</dd><dt className="col-sm-3">Category</dt><dd className="col-sm-9">{ticket.category.name}</dd><dt className="col-sm-3">Related System</dt><dd className="col-sm-9">{ticket.relatedSystem.name}</dd><dt className="col-sm-3">Requested Priority</dt><dd className="col-sm-9">{ticket.requestedPriority}</dd><dt className="col-sm-3">Status</dt><dd className="col-sm-9">{ticket.status}</dd></dl></div></div>
+    <div className="card shadow-sm"><div className="card-body"><h2 className="h4">Attachments</h2><div className="mb-4"><label className="form-label" htmlFor="attachment-file">Add attachment</label><input className="form-control" id="attachment-file" type="file" accept="image/jpeg,image/png,image/webp,application/pdf" onChange={(event) => setFile(event.target.files?.[0] ?? null)} />{uploadError && <div className="text-danger mt-1" role="alert">{uploadError}</div>}<button className="btn text-white mt-2" style={{ backgroundColor: "#006B3C" }} disabled={!file || uploading} onClick={() => void upload()}>{uploading ? "Uploading…" : "Upload attachment"}</button></div>
+      {ticket.attachments.length === 0 ? <p className="text-secondary mb-0">No attachments yet.</p> : <ul className="list-group">{ticket.attachments.map((attachment) => <li className="list-group-item" key={attachment.id}><div className="d-flex flex-wrap gap-2 align-items-center"><span className="me-auto text-break">{attachment.originalName} ({Math.ceil(attachment.sizeBytes / 1024)} KB)</span>{attachment.removedAt ? <span className="badge text-bg-secondary">Removed</span> : <><a className="btn btn-sm btn-outline-success" href={attachmentDownloadUrl(attachment.id, requester.id)}>Download</a><button className="btn btn-sm btn-outline-danger" onClick={() => setRemovingId(attachment.id)}>Remove</button></>}</div>{attachment.removedAt && <small className="text-secondary">Reason: {attachment.removalReason}</small>}{removingId === attachment.id && <div className="mt-2"><label className="form-label" htmlFor="removal-reason">Removal reason</label><input className="form-control" id="removal-reason" maxLength={500} value={removalReason} onChange={(event) => setRemovalReason(event.target.value)} />{removeError && <div className="text-danger mt-1" role="alert">{removeError}</div>}<button className="btn btn-danger btn-sm mt-2 me-2" disabled={removing || removalReason.trim().length === 0} onClick={() => void remove()}>{removing ? "Removing…" : "Confirm removal"}</button><button className="btn btn-outline-secondary btn-sm mt-2" disabled={removing} onClick={() => setRemovingId(null)}>Cancel</button></div>}</li>)}</ul>}
+    </div></div>
   </section>;
 }
 
@@ -202,6 +270,12 @@ export default function App() {
     <Route path="/select" element={<Navigate replace to="/tickets" />} />
     <Route path="/tickets" element={<Shell requester={requester} onChangeRequester={changeRequester}><MyTickets requester={requester} data={referenceData} /></Shell>} />
     <Route path="/tickets/new" element={<Shell requester={requester} onChangeRequester={changeRequester}><CreateTicket requester={requester} data={referenceData} /></Shell>} />
+    <Route path="/tickets/:ticketId" element={<Shell requester={requester} onChangeRequester={changeRequester}><TicketRoute requester={requester} /></Shell>} />
     <Route path="*" element={<Navigate replace to="/tickets" />} />
   </Routes>;
+}
+
+function TicketRoute({ requester }: { requester: Requester }) {
+  const ticketId = Number(useParams().ticketId);
+  return Number.isInteger(ticketId) && ticketId > 0 ? <TicketDetailPage requester={requester} ticketId={ticketId} /> : <Navigate replace to="/tickets" />;
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -48,6 +48,24 @@ export interface TicketListResponse {
   totalPages: number;
 }
 
+export interface Attachment {
+  id: number;
+  originalName: string;
+  mimeType: string;
+  sizeBytes: number;
+  createdAt: string;
+  removedAt: string | null;
+  removalReason: string | null;
+}
+
+export interface TicketDetail extends TicketListItem {
+  requesterId: number;
+  description: string;
+  createdAt: string;
+  relatedSystem: ReferenceItem;
+  attachments: Attachment[];
+}
+
 export interface TicketQuery {
   search?: string;
   categoryId?: string;
@@ -93,4 +111,32 @@ export async function loadTickets(requesterId: number, query: TicketQuery): Prom
   const body = await response.json().catch(() => ({}));
   if (!response.ok) throw new Error(typeof body.error === "string" ? body.error : "Unable to load tickets.");
   return body as TicketListResponse;
+}
+
+export async function loadTicket(ticketId: number, requesterId: number): Promise<TicketDetail> {
+  const response = await fetch(`${API_URL}/api/tickets/${ticketId}?requesterId=${requesterId}`);
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(typeof body.error === "string" ? body.error : "Unable to load ticket.");
+  return body as TicketDetail;
+}
+
+export async function uploadAttachment(ticketId: number, requesterId: number, file: File): Promise<Attachment> {
+  const form = new FormData();
+  form.set("requesterId", String(requesterId));
+  form.set("file", file);
+  const response = await fetch(`${API_URL}/api/tickets/${ticketId}/attachments`, { method: "POST", body: form });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(typeof body.error === "string" ? body.error : "Unable to upload attachment.");
+  return body as Attachment;
+}
+
+export async function removeAttachment(attachmentId: number, requesterId: number, reason: string): Promise<Attachment> {
+  const response = await fetch(`${API_URL}/api/attachments/${attachmentId}`, { method: "DELETE", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ requesterId, reason }) });
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(typeof body.error === "string" ? body.error : "Unable to remove attachment.");
+  return body as Attachment;
+}
+
+export function attachmentDownloadUrl(attachmentId: number, requesterId: number) {
+  return `${API_URL}/api/attachments/${attachmentId}/download?requesterId=${requesterId}`;
 }

--- a/client/tests/lab-02/RequesterTicketDetail.test.tsx
+++ b/client/tests/lab-02/RequesterTicketDetail.test.tsx
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import App from "../../src/App.js";
+import * as api from "../../src/api.js";
+
+const referenceData = { requesters: [{ id: 1, name: "Nicha Somchai", email: "nicha@example.test" }], categories: [{ id: 2, name: "Hardware" }], relatedSystems: [{ id: 3, name: "VPN" }] };
+const ticket = { id: 1, requesterId: 1, ticketNumber: "TKT-2026-A1B2C3D4", summary: "VPN cannot connect", description: "The VPN fails after login.", requestedPriority: "MEDIUM" as const, status: "NEW" as const, category: { id: 2, name: "Hardware" }, relatedSystem: { id: 3, name: "VPN" }, createdAt: "2026-08-25T00:00:00.000Z", updatedAt: "2026-08-25T00:00:00.000Z", attachments: [{ id: 4, originalName: "vpn.pdf", mimeType: "application/pdf", sizeBytes: 3, createdAt: "2026-08-25T00:00:00.000Z", removedAt: null, removalReason: null }] };
+
+function renderDetail() {
+  sessionStorage.setItem("toktickit.requesterId", "1");
+  return render(<MemoryRouter initialEntries={["/tickets/1"]}><App /></MemoryRouter>);
+}
+
+afterEach(() => {
+  sessionStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("Requester Ticket Detail", () => {
+  it("shows owned ticket data and preserves removed attachment metadata", async () => {
+    vi.spyOn(api, "loadReferenceData").mockResolvedValue(referenceData);
+    vi.spyOn(api, "loadTicket").mockResolvedValue(ticket);
+    vi.spyOn(api, "removeAttachment").mockResolvedValue({ ...ticket.attachments[0], removedAt: "2026-08-26T00:00:00.000Z", removalReason: "Wrong file" });
+    const user = userEvent.setup();
+    renderDetail();
+
+    expect(await screen.findByText("TKT-2026-A1B2C3D4")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    await user.type(screen.getByLabelText("Removal reason"), "Wrong file");
+    await user.click(screen.getByRole("button", { name: "Confirm removal" }));
+
+    expect(await screen.findByText("Removed")).toBeInTheDocument();
+    expect(screen.getByText("Reason: Wrong file")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Download" })).not.toBeInTheDocument();
+  });
+
+  it("keeps the selected file after an upload error", async () => {
+    vi.spyOn(api, "loadReferenceData").mockResolvedValue(referenceData);
+    vi.spyOn(api, "loadTicket").mockResolvedValue(ticket);
+    vi.spyOn(api, "uploadAttachment").mockRejectedValue(new Error("Unable to upload attachment."));
+    const user = userEvent.setup();
+    renderDetail();
+
+    const input = await screen.findByLabelText("Add attachment");
+    await user.upload(input, new File(["pdf"], "vpn.pdf", { type: "application/pdf" }));
+    await user.click(screen.getByRole("button", { name: "Upload attachment" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Unable to upload attachment.");
+    expect(input).toHaveValue("C:\\fakepath\\vpn.pdf");
+  });
+});

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -15,12 +15,12 @@ inactive requester.
 | API-01 | API | AC-01 | Active requester, Category, and Related System APIs exclude inactive data | `server/tests/lab-02/reference-data.api.test.ts` | Pass |
 | API-02 | API | AC-03, AC-04 | Valid ticket creates `NEW`; validation, inactive references, duplicate retry, and malformed JSON return safe responses | `server/tests/lab-02/create-ticket.api.test.ts` | Pass |
 | API-03 | API | AC-06, AC-08, AC-09 | Owned list search/filter/sort/page response is correct | `server/tests/lab-02/my-tickets.api.test.ts` | Pass |
-| API-04 | API | AC-07, AC-10 | Owned detail succeeds; cross-requester detail returns 404 | `server/tests/lab-02/ticket-detail.api.test.ts` | Planned |
-| API-05 | API | AC-11, AC-12, AC-13 | Upload, size/type/count limits, removal, and blocked download | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| API-04 | API | AC-07, AC-10 | Owned detail succeeds; cross-requester detail returns 404 | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Pass |
+| API-05 | API | AC-11, AC-12, AC-13 | Upload, size/type/count limits, removal, and blocked download | `server/tests/lab-02/ticket-detail-attachments.api.test.ts` | Pass |
 | UI-01 | UI | AC-01, AC-02 | Selector loading, empty, failure, selection, and Change Requester states | `client/tests/lab-02/RequesterSelection.test.tsx` | Pass |
 | UI-02 | UI | AC-03–AC-05 | Create form validation, busy, success, and retained failure values | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
 | UI-03 | UI | AC-06, AC-08, AC-09 | My Tickets loading, filters, pagination, empty/no-results/error states | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
-| UI-04 | UI | AC-10–AC-13 | Read-only detail and attachment action states | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
+| UI-04 | UI | AC-10–AC-13 | Read-only detail and attachment action states | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Pass |
 | STYLE-01 | UI style | AC-14 | Labels, asterisks, invalid classes, busy controls, and read-only treatment | `client/tests/lab-02/ui-style.test.tsx` | Planned |
 | E2E-01 | E2E | AC-03, AC-06, AC-10 | Requester creates a ticket and finds/opens it | `e2e/lab-02/requester-ticket-flow.spec.ts` | Planned |
 | E2E-02 | E2E | AC-07, AC-14 | Requester switch hides A's data; desktop/tablet/mobile screens remain usable | `e2e/lab-02/requester-ownership-responsive.spec.ts` | Planned |
@@ -95,6 +95,11 @@ My Tickets verification completed on `feature/10-my-tickets`:
 
 - Focused API tests cover requester ownership, filters, pagination, invalid queries, and safe failures.
 - Focused UI tests cover ticket display, filters, empty/no-match states, and retry.
+
+Ticket Detail and Attachments verification completed on `feature/11-ticket-detail-attachments`:
+
+- API tests cover owned/unowned access, type and size validation, five-file limit, upload, soft removal, and blocked download.
+- UI tests cover read-only detail, removal metadata/actions, and retained file selection after upload failure.
 
 ## 7. Known Limitations or Deferred Tests
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "cors": "^2.8.5",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "multer": "^2.2.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/multer": "^2.2.0",
         "@types/node": "^22.10.2",
         "@types/supertest": "^6.0.2",
         "prisma": "^5.22.0",
@@ -1023,6 +1025,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -1230,6 +1242,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1282,6 +1300,23 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1380,6 +1415,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -2035,6 +2085,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -2245,6 +2314,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/rollup": {
@@ -2482,6 +2565,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -2651,6 +2751,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2680,6 +2786,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -17,11 +17,13 @@
   "dependencies": {
     "@prisma/client": "^5.22.0",
     "cors": "^2.8.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "multer": "^2.2.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/multer": "^2.2.0",
     "@types/node": "^22.10.2",
     "@types/supertest": "^6.0.2",
     "prisma": "^5.22.0",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -14,6 +14,8 @@ const attachmentTypes = ["image/jpeg", "image/png", "image/webp", "application/p
 const attachmentSelect = { id: true, originalName: true, mimeType: true, sizeBytes: true, createdAt: true, removedAt: true, removalReason: true } as const;
 
 class AttachmentTypeError extends Error {}
+class AttachmentLimitError extends Error {}
+class TicketNotFoundError extends Error {}
 
 const upload = multer({
   storage: multer.memoryStorage(),
@@ -65,6 +67,14 @@ function queryChoice<T extends readonly string[]>(value: unknown, name: string, 
 function multipartId(value: unknown, name: string) {
   if (typeof value === "string" && /^\d+$/.test(value)) return requiredId(Number(value), name);
   return requiredId(value, name);
+}
+
+function hasAttachmentSignature(file: { mimetype: string; buffer: Buffer }) {
+  const { buffer, mimetype } = file;
+  if (mimetype === "application/pdf") return buffer.subarray(0, 5).equals(Buffer.from("%PDF-"));
+  if (mimetype === "image/png") return buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]));
+  if (mimetype === "image/jpeg") return buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff;
+  return buffer.subarray(0, 4).toString("ascii") === "RIFF" && buffer.subarray(8, 12).toString("ascii") === "WEBP";
 }
 
 async function requireActiveRequester(prisma: PrismaClient, requesterId: number) {
@@ -194,24 +204,34 @@ app.post("/api/tickets/:ticketId/attachments", upload.single("file"), async (req
     const requesterId = multipartId(req.body?.requesterId, "requesterId");
     const ticketId = queryInteger(req.params.ticketId, "ticketId");
     if (!req.file || req.file.originalname.length === 0 || req.file.originalname.length > 255) throw new RequestError("Attachment filename is invalid.");
+    const file = req.file;
+    if (!hasAttachmentSignature(file)) throw new AttachmentTypeError();
     const prisma = getPrisma();
     await requireActiveRequester(prisma, requesterId);
-    const ticket = await prisma.ticket.findFirst({ where: { id: ticketId, requesterId }, select: { id: true } });
-    if (!ticket) {
-      res.status(404).json({ error: "Ticket not found." });
-      return;
-    }
-    // ponytail: count-and-create can race under concurrent uploads; add a transaction/lock if uploads become concurrent.
-    if (await prisma.attachment.count({ where: { ticketId, removedAt: null } }) >= 5) {
-      res.status(409).json({ error: "A ticket can have at most five active attachments." });
-      return;
-    }
-    storageKey = randomUUID();
-    await saveAttachment(storageKey, req.file.buffer);
-    const attachment = await prisma.attachment.create({ data: { ticketId, originalName: req.file.originalname, storageKey, mimeType: req.file.mimetype, sizeBytes: req.file.size }, select: attachmentSelect });
+    const attachment = await prisma.$transaction(async (transaction) => {
+      await transaction.$executeRaw`SELECT pg_advisory_xact_lock(${ticketId})`;
+      const ticket = await transaction.ticket.findFirst({ where: { id: ticketId, requesterId }, select: { id: true } });
+      if (!ticket) throw new TicketNotFoundError();
+      if (await transaction.attachment.count({ where: { ticketId, removedAt: null } }) >= 5) throw new AttachmentLimitError();
+      storageKey = randomUUID();
+      await saveAttachment(storageKey, file.buffer);
+      return transaction.attachment.create({ data: { ticketId, originalName: file.originalname, storageKey, mimeType: file.mimetype, sizeBytes: file.size }, select: attachmentSelect });
+    });
     res.status(201).json(attachment);
   } catch (error) {
     if (storageKey) await discardAttachment(storageKey);
+    if (error instanceof AttachmentTypeError) {
+      res.status(415).json({ error: "Attachment type is not permitted." });
+      return;
+    }
+    if (error instanceof TicketNotFoundError) {
+      res.status(404).json({ error: "Ticket not found." });
+      return;
+    }
+    if (error instanceof AttachmentLimitError) {
+      res.status(409).json({ error: "A ticket can have at most five active attachments." });
+      return;
+    }
     if (error instanceof RequestError) {
       res.status(400).json({ error: error.message });
       return;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,12 +1,28 @@
 import express, { NextFunction, Request, Response } from "express";
 import cors from "cors";
+import multer from "multer";
+import { randomUUID } from "node:crypto";
 import type { Prisma, PrismaClient } from "@prisma/client";
 import { getPrisma } from "./prisma.js";
 import { generateTicketNumber } from "./ticket-number.js";
+import { attachmentPath, discardAttachment, saveAttachment } from "./attachment-storage.js";
 
 const priorities = ["LOW", "MEDIUM", "HIGH", "URGENT"] as const;
 const statuses = ["NEW"] as const;
 const sortFields = ["updatedAt", "createdAt", "ticketNumber", "requestedPriority"] as const;
+const attachmentTypes = ["image/jpeg", "image/png", "image/webp", "application/pdf"];
+const attachmentSelect = { id: true, originalName: true, mimeType: true, sizeBytes: true, createdAt: true, removedAt: true, removalReason: true } as const;
+
+class AttachmentTypeError extends Error {}
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 5 * 1024 * 1024, files: 1 },
+  fileFilter: (_req, file, callback) => {
+    if (attachmentTypes.includes(file.mimetype)) callback(null, true);
+    else callback(new AttachmentTypeError());
+  },
+});
 
 class RequestError extends Error {
   constructor(readonly message: string) { super(message); }
@@ -44,6 +60,11 @@ function queryChoice<T extends readonly string[]>(value: unknown, name: string, 
   if (value === undefined) return fallback;
   if (typeof value !== "string" || !choices.includes(value)) throw new RequestError(`${name} is invalid.`);
   return value as T[number];
+}
+
+function multipartId(value: unknown, name: string) {
+  if (typeof value === "string" && /^\d+$/.test(value)) return requiredId(Number(value), name);
+  return requiredId(value, name);
 }
 
 async function requireActiveRequester(prisma: PrismaClient, requesterId: number) {
@@ -143,6 +164,128 @@ app.get("/api/tickets", async (req: Request, res: Response) => {
   }
 });
 
+app.get("/api/tickets/:ticketId", async (req: Request, res: Response) => {
+  try {
+    const requesterId = queryInteger(req.query.requesterId, "requesterId");
+    const ticketId = queryInteger(req.params.ticketId, "ticketId");
+    const prisma = getPrisma();
+    await requireActiveRequester(prisma, requesterId);
+    const ticket = await prisma.ticket.findFirst({
+      where: { id: ticketId, requesterId },
+      select: { id: true, ticketNumber: true, requesterId: true, summary: true, description: true, requestedPriority: true, status: true, createdAt: true, updatedAt: true, category: { select: { id: true, name: true } }, relatedSystem: { select: { id: true, name: true } }, attachments: { orderBy: { createdAt: "desc" }, select: attachmentSelect } },
+    });
+    if (!ticket) {
+      res.status(404).json({ error: "Ticket not found." });
+      return;
+    }
+    res.json(ticket);
+  } catch (error) {
+    if (error instanceof RequestError) {
+      res.status(400).json({ error: error.message });
+      return;
+    }
+    res.status(500).json({ error: "Unable to load ticket." });
+  }
+});
+
+app.post("/api/tickets/:ticketId/attachments", upload.single("file"), async (req: Request, res: Response) => {
+  let storageKey: string | null = null;
+  try {
+    const requesterId = multipartId(req.body?.requesterId, "requesterId");
+    const ticketId = queryInteger(req.params.ticketId, "ticketId");
+    if (!req.file || req.file.originalname.length === 0 || req.file.originalname.length > 255) throw new RequestError("Attachment filename is invalid.");
+    const prisma = getPrisma();
+    await requireActiveRequester(prisma, requesterId);
+    const ticket = await prisma.ticket.findFirst({ where: { id: ticketId, requesterId }, select: { id: true } });
+    if (!ticket) {
+      res.status(404).json({ error: "Ticket not found." });
+      return;
+    }
+    // ponytail: count-and-create can race under concurrent uploads; add a transaction/lock if uploads become concurrent.
+    if (await prisma.attachment.count({ where: { ticketId, removedAt: null } }) >= 5) {
+      res.status(409).json({ error: "A ticket can have at most five active attachments." });
+      return;
+    }
+    storageKey = randomUUID();
+    await saveAttachment(storageKey, req.file.buffer);
+    const attachment = await prisma.attachment.create({ data: { ticketId, originalName: req.file.originalname, storageKey, mimeType: req.file.mimetype, sizeBytes: req.file.size }, select: attachmentSelect });
+    res.status(201).json(attachment);
+  } catch (error) {
+    if (storageKey) await discardAttachment(storageKey);
+    if (error instanceof RequestError) {
+      res.status(400).json({ error: error.message });
+      return;
+    }
+    res.status(500).json({ error: "Unable to upload attachment." });
+  }
+});
+
+app.get("/api/attachments/:attachmentId", async (req: Request, res: Response) => {
+  try {
+    const requesterId = queryInteger(req.query.requesterId, "requesterId");
+    const attachmentId = queryInteger(req.params.attachmentId, "attachmentId");
+    const prisma = getPrisma();
+    await requireActiveRequester(prisma, requesterId);
+    const attachment = await prisma.attachment.findFirst({ where: { id: attachmentId, ticket: { requesterId } }, select: attachmentSelect });
+    if (!attachment) {
+      res.status(404).json({ error: "Attachment not found." });
+      return;
+    }
+    res.json(attachment);
+  } catch (error) {
+    if (error instanceof RequestError) {
+      res.status(400).json({ error: error.message });
+      return;
+    }
+    res.status(500).json({ error: "Unable to load attachment." });
+  }
+});
+
+app.get("/api/attachments/:attachmentId/download", async (req: Request, res: Response) => {
+  try {
+    const requesterId = queryInteger(req.query.requesterId, "requesterId");
+    const attachmentId = queryInteger(req.params.attachmentId, "attachmentId");
+    const prisma = getPrisma();
+    await requireActiveRequester(prisma, requesterId);
+    const attachment = await prisma.attachment.findFirst({ where: { id: attachmentId, removedAt: null, ticket: { requesterId } }, select: { originalName: true, mimeType: true, storageKey: true } });
+    if (!attachment) {
+      res.status(404).json({ error: "Attachment not found." });
+      return;
+    }
+    res.type(attachment.mimeType).download(attachmentPath(attachment.storageKey), attachment.originalName, (error) => {
+      if (error && !res.headersSent) res.status(500).json({ error: "Unable to download attachment." });
+    });
+  } catch (error) {
+    if (error instanceof RequestError) {
+      res.status(400).json({ error: error.message });
+      return;
+    }
+    res.status(500).json({ error: "Unable to download attachment." });
+  }
+});
+
+app.delete("/api/attachments/:attachmentId", async (req: Request, res: Response) => {
+  try {
+    const requesterId = requiredId(req.body?.requesterId, "requesterId");
+    const attachmentId = queryInteger(req.params.attachmentId, "attachmentId");
+    const reason = requiredText(req.body?.reason, "reason", 1, 500);
+    const prisma = getPrisma();
+    await requireActiveRequester(prisma, requesterId);
+    const attachment = await prisma.attachment.findFirst({ where: { id: attachmentId, removedAt: null, ticket: { requesterId } }, select: { id: true } });
+    if (!attachment) {
+      res.status(404).json({ error: "Attachment not found." });
+      return;
+    }
+    res.json(await prisma.attachment.update({ where: { id: attachmentId }, data: { removedAt: new Date(), removalReason: reason }, select: attachmentSelect }));
+  } catch (error) {
+    if (error instanceof RequestError) {
+      res.status(400).json({ error: error.message });
+      return;
+    }
+    res.status(500).json({ error: "Unable to remove attachment." });
+  }
+});
+
 app.post("/api/tickets", async (req: Request, res: Response) => {
   try {
     const requesterId = requiredId(req.body?.requesterId, "requesterId");
@@ -181,6 +324,18 @@ app.post("/api/tickets", async (req: Request, res: Response) => {
     }
     res.status(500).json({ error: "Unable to create ticket." });
   }
+});
+
+app.use((error: Error, _req: Request, res: Response, next: NextFunction) => {
+  if (error instanceof multer.MulterError) {
+    res.status(error.code === "LIMIT_FILE_SIZE" ? 413 : 400).json({ error: error.code === "LIMIT_FILE_SIZE" ? "Attachment exceeds the 5 MB limit." : "Invalid attachment upload." });
+    return;
+  }
+  if (error instanceof AttachmentTypeError) {
+    res.status(415).json({ error: "Attachment type is not permitted." });
+    return;
+  }
+  next(error);
 });
 
 export default app;

--- a/server/src/attachment-storage.ts
+++ b/server/src/attachment-storage.ts
@@ -1,0 +1,18 @@
+import { mkdir, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const uploadDirectory = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "uploads");
+
+export function attachmentPath(storageKey: string) {
+  return path.join(uploadDirectory, storageKey);
+}
+
+export async function saveAttachment(storageKey: string, contents: Buffer) {
+  await mkdir(uploadDirectory, { recursive: true });
+  await writeFile(attachmentPath(storageKey), contents, { flag: "wx" });
+}
+
+export async function discardAttachment(storageKey: string) {
+  await unlink(attachmentPath(storageKey)).catch(() => undefined);
+}

--- a/server/tests/lab-02/ticket-detail-attachments.api.test.ts
+++ b/server/tests/lab-02/ticket-detail-attachments.api.test.ts
@@ -2,10 +2,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import request from "supertest";
 
 const storage = vi.hoisted(() => ({ attachmentPath: vi.fn((key: string) => `/uploads/${key}`), discardAttachment: vi.fn(), saveAttachment: vi.fn() }));
+const transaction = vi.hoisted(() => ({ $executeRaw: vi.fn(), ticket: { findFirst: vi.fn() }, attachment: { count: vi.fn(), create: vi.fn() } }));
 const prisma = vi.hoisted(() => ({
   requester: { findFirst: vi.fn() },
   ticket: { findFirst: vi.fn() },
   attachment: { count: vi.fn(), create: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
+  $transaction: vi.fn(),
 }));
 
 vi.mock("../../src/prisma.js", () => ({ getPrisma: () => prisma }));
@@ -14,10 +16,12 @@ vi.mock("../../src/attachment-storage.js", () => storage);
 import { app } from "../../src/app.js";
 
 const attachment = { id: 4, originalName: "vpn.pdf", mimeType: "application/pdf", sizeBytes: 3, createdAt: new Date(), removedAt: null, removalReason: null };
+const pdf = Buffer.from("%PDF-1.4\n");
 
 beforeEach(() => {
   vi.resetAllMocks();
   prisma.requester.findFirst.mockResolvedValue({ id: 1 });
+  prisma.$transaction.mockImplementation((callback: (client: typeof transaction) => unknown) => callback(transaction));
 });
 
 describe("requester ticket detail and attachments", () => {
@@ -33,17 +37,25 @@ describe("requester ticket detail and attachments", () => {
   });
 
   it("uploads a permitted owned attachment and rejects an unsupported type", async () => {
-    prisma.ticket.findFirst.mockResolvedValue({ id: 1 });
-    prisma.attachment.count.mockResolvedValue(0);
-    prisma.attachment.create.mockResolvedValue(attachment);
+    transaction.ticket.findFirst.mockResolvedValue({ id: 1 });
+    transaction.attachment.count.mockResolvedValue(0);
+    transaction.attachment.create.mockResolvedValue(attachment);
 
-    const created = await request(app).post("/api/tickets/1/attachments").field("requesterId", "1").attach("file", Buffer.from("pdf"), { filename: "vpn.pdf", contentType: "application/pdf" });
+    const created = await request(app).post("/api/tickets/1/attachments").field("requesterId", "1").attach("file", pdf, { filename: "vpn.pdf", contentType: "application/pdf" });
     const rejected = await request(app).post("/api/tickets/1/attachments").field("requesterId", "1").attach("file", Buffer.from("text"), { filename: "note.txt", contentType: "text/plain" });
 
     expect(created.status).toBe(201);
     expect(created.body).toMatchObject({ originalName: "vpn.pdf" });
     expect(storage.saveAttachment).toHaveBeenCalled();
     expect(rejected.status).toBe(415);
+  });
+
+  it("rejects spoofed PDF content before storing it", async () => {
+    const response = await request(app).post("/api/tickets/1/attachments").field("requesterId", "1").attach("file", Buffer.from("not a PDF"), { filename: "spoofed.pdf", contentType: "application/pdf" });
+
+    expect(response.status).toBe(415);
+    expect(storage.saveAttachment).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 
   it("returns attachment metadata only for its owner", async () => {
@@ -57,17 +69,32 @@ describe("requester ticket detail and attachments", () => {
     expect(unowned.status).toBe(404);
   });
 
-  it("rejects an oversized or sixth attachment and blocks removed downloads", async () => {
+  it("serializes the active-file check with a per-ticket transaction lock", async () => {
     const oversized = await request(app).post("/api/tickets/1/attachments").field("requesterId", "1").attach("file", Buffer.alloc(5 * 1024 * 1024 + 1), { filename: "large.pdf", contentType: "application/pdf" });
-    prisma.ticket.findFirst.mockResolvedValue({ id: 1 });
-    prisma.attachment.count.mockResolvedValue(5);
-    const sixth = await request(app).post("/api/tickets/1/attachments").field("requesterId", "1").attach("file", Buffer.from("pdf"), { filename: "sixth.pdf", contentType: "application/pdf" });
+    transaction.ticket.findFirst.mockResolvedValue({ id: 1 });
+    transaction.attachment.count.mockResolvedValue(5);
+    const sixth = await request(app).post("/api/tickets/1/attachments").field("requesterId", "1").attach("file", pdf, { filename: "sixth.pdf", contentType: "application/pdf" });
     prisma.attachment.findFirst.mockResolvedValue(null);
     const removedDownload = await request(app).get("/api/attachments/4/download?requesterId=1");
 
     expect(oversized.status).toBe(413);
     expect(sixth.status).toBe(409);
     expect(removedDownload.status).toBe(404);
+    expect(transaction.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(transaction.$executeRaw.mock.calls[0][0].join("")).toContain("pg_advisory_xact_lock");
+    expect(transaction.attachment.create).not.toHaveBeenCalled();
+  });
+
+  it("discards a stored file when the attachment transaction fails", async () => {
+    transaction.ticket.findFirst.mockResolvedValue({ id: 1 });
+    transaction.attachment.count.mockResolvedValue(0);
+    transaction.attachment.create.mockRejectedValue(new Error("database unavailable"));
+
+    const response = await request(app).post("/api/tickets/1/attachments").field("requesterId", "1").attach("file", pdf, { filename: "vpn.pdf", contentType: "application/pdf" });
+
+    expect(response.status).toBe(500);
+    expect(storage.saveAttachment).toHaveBeenCalledTimes(1);
+    expect(storage.discardAttachment).toHaveBeenCalledTimes(1);
   });
 
   it("soft-removes an owned active attachment and returns 404 for an unowned one", async () => {

--- a/server/tests/lab-02/ticket-detail-attachments.api.test.ts
+++ b/server/tests/lab-02/ticket-detail-attachments.api.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import request from "supertest";
+
+const storage = vi.hoisted(() => ({ attachmentPath: vi.fn((key: string) => `/uploads/${key}`), discardAttachment: vi.fn(), saveAttachment: vi.fn() }));
+const prisma = vi.hoisted(() => ({
+  requester: { findFirst: vi.fn() },
+  ticket: { findFirst: vi.fn() },
+  attachment: { count: vi.fn(), create: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
+}));
+
+vi.mock("../../src/prisma.js", () => ({ getPrisma: () => prisma }));
+vi.mock("../../src/attachment-storage.js", () => storage);
+
+import { app } from "../../src/app.js";
+
+const attachment = { id: 4, originalName: "vpn.pdf", mimeType: "application/pdf", sizeBytes: 3, createdAt: new Date(), removedAt: null, removalReason: null };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  prisma.requester.findFirst.mockResolvedValue({ id: 1 });
+});
+
+describe("requester ticket detail and attachments", () => {
+  it("returns an owned ticket detail and hides an unowned ticket", async () => {
+    prisma.ticket.findFirst.mockResolvedValueOnce({ id: 1, ticketNumber: "TKT-2026-A1B2C3D4", summary: "VPN cannot connect", description: "The VPN fails after login.", requestedPriority: "MEDIUM", status: "NEW", category: { id: 2, name: "Hardware" }, relatedSystem: { id: 3, name: "VPN" }, attachments: [attachment] }).mockResolvedValueOnce(null);
+
+    const owned = await request(app).get("/api/tickets/1?requesterId=1");
+    const unowned = await request(app).get("/api/tickets/2?requesterId=1");
+
+    expect(owned.status).toBe(200);
+    expect(owned.body.attachments[0]).toMatchObject({ originalName: "vpn.pdf" });
+    expect(unowned.status).toBe(404);
+  });
+
+  it("uploads a permitted owned attachment and rejects an unsupported type", async () => {
+    prisma.ticket.findFirst.mockResolvedValue({ id: 1 });
+    prisma.attachment.count.mockResolvedValue(0);
+    prisma.attachment.create.mockResolvedValue(attachment);
+
+    const created = await request(app).post("/api/tickets/1/attachments").field("requesterId", "1").attach("file", Buffer.from("pdf"), { filename: "vpn.pdf", contentType: "application/pdf" });
+    const rejected = await request(app).post("/api/tickets/1/attachments").field("requesterId", "1").attach("file", Buffer.from("text"), { filename: "note.txt", contentType: "text/plain" });
+
+    expect(created.status).toBe(201);
+    expect(created.body).toMatchObject({ originalName: "vpn.pdf" });
+    expect(storage.saveAttachment).toHaveBeenCalled();
+    expect(rejected.status).toBe(415);
+  });
+
+  it("returns attachment metadata only for its owner", async () => {
+    prisma.attachment.findFirst.mockResolvedValueOnce(attachment).mockResolvedValueOnce(null);
+
+    const owned = await request(app).get("/api/attachments/4?requesterId=1");
+    const unowned = await request(app).get("/api/attachments/5?requesterId=1");
+
+    expect(owned.status).toBe(200);
+    expect(owned.body).toMatchObject({ originalName: "vpn.pdf" });
+    expect(unowned.status).toBe(404);
+  });
+
+  it("rejects an oversized or sixth attachment and blocks removed downloads", async () => {
+    const oversized = await request(app).post("/api/tickets/1/attachments").field("requesterId", "1").attach("file", Buffer.alloc(5 * 1024 * 1024 + 1), { filename: "large.pdf", contentType: "application/pdf" });
+    prisma.ticket.findFirst.mockResolvedValue({ id: 1 });
+    prisma.attachment.count.mockResolvedValue(5);
+    const sixth = await request(app).post("/api/tickets/1/attachments").field("requesterId", "1").attach("file", Buffer.from("pdf"), { filename: "sixth.pdf", contentType: "application/pdf" });
+    prisma.attachment.findFirst.mockResolvedValue(null);
+    const removedDownload = await request(app).get("/api/attachments/4/download?requesterId=1");
+
+    expect(oversized.status).toBe(413);
+    expect(sixth.status).toBe(409);
+    expect(removedDownload.status).toBe(404);
+  });
+
+  it("soft-removes an owned active attachment and returns 404 for an unowned one", async () => {
+    prisma.attachment.findFirst.mockResolvedValueOnce({ id: 4 }).mockResolvedValueOnce(null);
+    prisma.attachment.update.mockResolvedValue({ ...attachment, removedAt: new Date(), removalReason: "Wrong file" });
+
+    const removed = await request(app).delete("/api/attachments/4").send({ requesterId: 1, reason: "Wrong file" });
+    const unowned = await request(app).delete("/api/attachments/5").send({ requesterId: 1, reason: "Wrong file" });
+
+    expect(removed.status).toBe(200);
+    expect(removed.body.removalReason).toBe("Wrong file");
+    expect(unowned.status).toBe(404);
+  });
+});


### PR DESCRIPTION
Closes #18

## Summary
- add requester-owned Ticket Detail API and read-only UI
- add local attachment upload, metadata, download, and soft removal with ownership and limits
- validate uploaded content signatures and serialize the five-active-file decision with a PostgreSQL transaction lock
- add Multer multipart validation, API/UI coverage, and Lab 2 test traceability

## Verification
- npm test --prefix server (32 passing)
- npm run build --prefix server
- npm test --prefix client (14 passing)
- npm run build --prefix client

Stacked on #24; retarget to lab2-staging after #24 merges.